### PR TITLE
maint: remove logs/doom.log, update indent-blankline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 logs/
 plugin/
 sessions/
+logs/doom.log

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -216,7 +216,6 @@ return packer.startup(function()
 		Has_value(Doom.disabled_plugins, 'indentlines')
 	use({
 		'lukas-reineke/indent-blankline.nvim',
-		branch = 'lua',
 		disable = (disabled_files and true or disabled_indent_lines),
 	})
 


### PR DESCRIPTION
doom.log keeps showing up as modified, even though logs/ is in the .gitignore file.

This change removes doom.log and adds it specifically to the .gitignore file.

Second commit removes the 'lua' branch from indent-blankline to prevent warning popup, moving the plugin to master.