### PR TITLE
use /usr/bin/env bash to make install more portable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 #================================================
 # install.sh - Doom Nvim Installation Script
 # Author: NTBBloodbath


### PR DESCRIPTION
/usr/bin/bash and /bin/bash aren't guaranteed to exist on many systems, but /usr/bin/env is. This change makes the shebang line /usr/bin/env bash so it works on any modern *nix type system.  Tested in macOS, Ubuntu and WSL.