### PR TITLE
Assume ~/.config/nvim rather than ~/.config/doom-nvim in lua code

### DIFF
--- a/lua/doom/core/functions/init.lua
+++ b/lua/doom/core/functions/init.lua
@@ -93,7 +93,7 @@ M.quit_doom = function(write, force)
 					.. config.doom.colorscheme
 					.. "'/'"
 					.. target_colorscheme
-					.. '\'/" $HOME/.config/doom-nvim/doom_config.lua'
+					.. '\'/" $HOME/.config/nvim/doom_config.lua'
 			)
 			log.info(
 				'Colorscheme successfully changed to ' .. target_colorscheme
@@ -105,7 +105,7 @@ M.quit_doom = function(write, force)
 					.. config.doom.colorscheme_bg
 					.. "'/'"
 					.. target_background
-					.. '\'/" $HOME/.config/doom-nvim/doom_config.lua'
+					.. '\'/" $HOME/.config/nvim/doom_config.lua'
 			)
 			log.info('Background successfully changed to ' .. target_background)
 		end

--- a/lua/doom/core/keybindings/init.lua
+++ b/lua/doom/core/keybindings/init.lua
@@ -257,7 +257,7 @@ utils.map('n', '<leader>bf', '<cmd>FormatWrite<CR>', opts)
 utils.map(
 	'n',
 	'<leader>dc',
-	'<cmd>e ~/.config/doom-nvim/doom_config.lua<CR>',
+	'<cmd>e ~/.config/nvim/doom_config.lua<CR>',
 	opts
 )
 utils.map('n', '<leader>dd', '<cmd>help doom_nvim<CR>', opts)

--- a/lua/doom/modules/config/doom-dashboard.lua
+++ b/lua/doom/modules/config/doom-dashboard.lua
@@ -28,7 +28,7 @@ return function()
 		},
 		f = {
 			description = { '  Open Private Configuration     SPC d c' },
-			command = ':e ~/.config/doom-nvim/doomrc',
+			command = ':e ~/.config/nvim/doomrc',
 		},
 		g = {
 			description = { '  Open Documentation             SPC d d' },

--- a/lua/doom/utils/init.lua
+++ b/lua/doom/utils/init.lua
@@ -11,7 +11,7 @@ local M = {}
 M.doom_version = '3.0.0'
 
 -- Local files
-M.doom_root = vim.fn.expand('$HOME/.config/doom-nvim')
+M.doom_root = vim.fn.expand('$HOME/.config/nvim')
 M.doom_logs = vim.fn.stdpath('data') .. '/doom.log'
 M.doom_report = vim.fn.stdpath('data') .. '/doom_report.md'
 


### PR DESCRIPTION
For people wanting control over install locations, prefer the ~/.config/nvim location in lua code so it is easier to experiment with doom-nvim.
The install process can stay with ~/.config/doom-nvim.