### PR TITLE
fix(gitsigns): `use_internal_diff` has been replaced with `diff_opts.internal`

### DIFF
--- a/lua/doom/modules/config/doom-gitsigns.lua
+++ b/lua/doom/modules/config/doom-gitsigns.lua
@@ -67,6 +67,8 @@ return function()
     sign_priority = 6,
     update_debounce = 100,
     status_formatter = nil, -- Use default
-    use_internal_diff = true, -- If luajit is present
+    diff_opts = {
+      internal = true, -- If luajit is present
+    },
   })
 end


### PR DESCRIPTION
update the gitsigns setup according to this changes
<https://github.com/lewis6991/gitsigns.nvim/commit/34deec281323c14c20a6f44070d4c1f668dfb2b0>