### PR TITLE
fix(modules): update gitsigns configuration

### DIFF
--- a/lua/doom/modules/config/doom-gitsigns.lua
+++ b/lua/doom/modules/config/doom-gitsigns.lua
@@ -61,11 +61,10 @@ return function()
     },
     watch_index = { interval = 1000, follow_files = true },
     current_line_blame = false,
-    current_line_blame_delay = 1000,
-    current_line_blame_position = "eol",
+    current_line_blame_opts = { delay = 1000, virt_text_pos = "eol" },
     sign_priority = 6,
     update_debounce = 100,
     status_formatter = nil, -- Use default
-    use_internal_diff = true, -- If luajit is present
+    diff_opts = { internal = true }, -- If luajit is present
   })
 end


### PR DESCRIPTION
With this patch, deprecation notice will be gone and nice

Changes for gitsigns
34deec2 ("Add config.diff_opts and deprecate fields", 2021-09-09)

use_internal_diff is now deprecated,lease use diff_opts.internal
current_line_blame_delay is now deprecated,lease use current_line_blame_opts.delay
current_line_blame_position is now deprecated,lease use current_line_blame_opts.virt_text_pos

Signed-off-by: Osamu Aoki <osamu@debian.org>