### PR TITLE
modeline by nvim 0.5 is as secure

### DIFF
--- a/doom_config.lua
+++ b/doom_config.lua
@@ -349,7 +349,16 @@ M.config = {
     -- Set custom Neovim global variables
     -- @default = {}
     -- example:
-    --   { ['sonokai_style'] = 'andromeda' }
+    --   {
+    --     ['sonokai_style'] = 'andromeda',
+    --     ['modelineexpr'] = true,
+    --   }
+    --
+    --   modeline feature was turned off to reduce security exploit surfaces.
+    --   Since modeline now uses whitelist approach since nvim 0.4 /vim 8.1,
+    --   enabling this is as safe as external packages such as securemodelines.
+    --   See https://github.com/neovim/neovim/issues/2865
+    --
     global_variables = {},
 
     -- Set custom autocommands


### PR DESCRIPTION
Here is a patch for https://github.com/NTBBloodbath/doom-nvim/issues/134

Mode line is lines such as
`# vim:set ai si ts=2 sts=2 sw=2 et:`

This can set vim some limitted options.

---

Vim's modeline was known to be security risk.

Arbitrary code execution issue was initially addressed by Vim upstream
using sandbox approach.  Nvim developer found security bug in this
sandboxing code.  This history made Nvim to disable this feature.  Vim
distributors such as Debian also disable this feature in its default
install, too.

Considering the recent change[*] to use more restrictive whitelist
approach, use of modeline became as secure as external packages
such as securemodelines written in vimL.

  [*] https://github.com/neovim/neovim/issues/2865

Signed-off-by: Osamu Aoki <osamu@debian.org>