### PR TITLE
feat(gitignore): ignore editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tags
 # Backup files
 .doom_releases
 .doom_backup_hash
+# editor artifacts
+*~
+*.swp


### PR DESCRIPTION
Swap file help recovering data when editor crashes.
Currently, doom-nvim sets swap as off.  That's OK.
But please consider excluding them in .gitignore.