### PR TITLE
fix(modules): correct usage of config property

### DIFF
--- a/lua/doom/modules/config/doom-tree.lua
+++ b/lua/doom/modules/config/doom-tree.lua
@@ -1,5 +1,5 @@
 return function()
-  local config = require("doom.core.config").config
+  local config = require("doom.core.config").load_config()
   local tree_cb = require("nvim-tree.config").nvim_tree_callback
 
   ----- GLOBAL VARIABLES ------------------------


### PR DESCRIPTION
doom.core.config does not hold `config` property, so `load_config` has to be used