### PR TITLE
[WIP] Fixed LSP servers not installing with +lsp in doomrc

### DIFF
--- a/lua/doom/core/config/init.lua
+++ b/lua/doom/core/config/init.lua
@@ -433,13 +433,6 @@ M.load_config = function()
   return config
 end
 
--- install_servers will install the language servers for the languages with
--- the +lsp flag.
---
--- @param langs The list of languages in the doomrc
-M.install_servers = function(langs)
-end
-
 -- install_dap_clients will install the DAP clients for the languages with
 -- the +debug flag.
 --

--- a/lua/doom/core/config/init.lua
+++ b/lua/doom/core/config/init.lua
@@ -438,30 +438,6 @@ end
 --
 -- @param langs The list of languages in the doomrc
 M.install_servers = function(langs)
-  -- selene: allow(undefined_variable)
-  if packer_plugins and packer_plugins["lspinstall"] and packer_plugins["lspinstall"].loaded then
-    local lspinstall = require("lspinstall")
-    local installed_servers = lspinstall.installed_servers()
-    local available_servers = lspinstall.available_servers()
-
-    for _, lang in ipairs(langs) do
-      local lang_str = lang
-      lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
-
-      -- If the +lsp flag exists and the language server is not installed yet
-      if lang_str:find("%+lsp") and (not utils.has_value(installed_servers, lang)) then
-        -- Try to install the server only if there is a server available for
-        -- the language, oterwise raise a warning
-        if utils.has_value(available_servers, lang) then
-          lspinstall.install_server(lang)
-        else
-          log.warn(
-            "The language " .. lang .. ' does not have a server, please remove the "+lsp" flag'
-          )
-        end
-      end
-    end
-  end
 end
 
 -- install_dap_clients will install the DAP clients for the languages with

--- a/lua/doom/core/init.lua
+++ b/lua/doom/core/init.lua
@@ -24,10 +24,6 @@ for i = 1, #core_modules, 1 do
       -- User-defined settings (global variables, mappings, ect)
       require("doom.core.settings").custom_options()
     elseif core_modules[i] == "config" then
-      -- Automatically install language servers
-      require("doom.core.config").install_servers(
-        require("doom.core.config.doomrc").load_doomrc().langs
-      )
       -- Automatically install language DAP clients
       require("doom.core.config").install_dap_clients(
         require("doom.core.config.doomrc").load_doomrc().langs

--- a/lua/doom/modules/config/doom-lspinstall.lua
+++ b/lua/doom/modules/config/doom-lspinstall.lua
@@ -1,4 +1,5 @@
 return function()
+  local log = require("doom.extras.logging")
   local utils = require("doom.utils")
   local nvim_lsp = require("lspconfig")
   local lua_lsp = require("lua-dev").setup({
@@ -13,13 +14,11 @@ return function()
     },
   })
 
-  log.info('Importing LSP install')
   local lspinstall = require("lspinstall")
   lspinstall.setup()
 
   -- Load langs from doomrc and install servers with +lsp 
   local function install_servers()
-    log.info('Installing servers now ...')
     local installed_servers = lspinstall.installed_servers()
     local available_servers = lspinstall.available_servers()
 


### PR DESCRIPTION
I think the issue is due to a race condition from the part of the code that installs the LSPs running before Packer is done lazy loading nvim-lspinstall and nvim-lspconfig.  I mirrored the way nvim-treesitter works by moving the installation into the config file of `nvim-lspinstall`.  There's still some bugs that I need to iron out before this is production ready.

This is still a work in progress, open to feedback :)

Start of discussion in #87 