### PR TITLE
Fixed DAPInstall.nvim auto install

### DIFF
--- a/lua/doom/core/config/init.lua
+++ b/lua/doom/core/config/init.lua
@@ -7,7 +7,6 @@
 local M = {}
 
 local log = require("doom.extras.logging")
-local utils = require("doom.utils")
 local system = require("doom.core.system")
 
 log.debug("Loading Doom config module ...")

--- a/lua/doom/core/config/init.lua
+++ b/lua/doom/core/config/init.lua
@@ -440,43 +440,6 @@ else
   end
 end
 
--- install_dap_clients will install the DAP clients for the languages with
--- the +debug flag.
---
--- @param langs The list of languages in the doom_modules.lua
-M.install_dap_clients = function(langs)
-  if
-    packer_plugins
-    and packer_plugins["DAPInstall.nvim"]
-    and packer_plugins["DAPInstall.nvim"].loaded
-  then
-    local installed_clients = require("dap-install.api.debuggers").get_installed_debuggers()
-    -- NOTE: not all the clients follows the 'language_dbg' standard and this
-    --       can give some problems to us (maybe?)
-    local available_clients = vim.tbl_keys(require("dap-install.api.debuggers").get_debuggers())
-
-    for _, lang in ipairs(langs) do
-      local lang_str = lang
-      lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
-
-      -- If the +debug flag exists and the language client is not installed yet
-      if lang_str:find("%+debug") and (not utils.has_value(installed_clients, lang .. "_dbg")) then
-        -- Try to install the client only if there is a client available for
-        -- the language, oterwise raise a warning
-        if utils.has_value(available_clients, lang .. "_dbg") then
-          require("dap-install.tools.tool_install").install_debugger(lang .. "_dbg")
-        else
-          log.warn(
-            "The language "
-              .. lang
-              .. ' does not have a DAP client, please remove the "+debug" flag'
-          )
-        end
-      end
-    end
-  end
-end
-
 -- Check plugins updates on start if enabled
 if M.config.doom.check_updates then
   require("doom.core.functions").check_updates()

--- a/lua/doom/core/init.lua
+++ b/lua/doom/core/init.lua
@@ -17,11 +17,6 @@ for i = 1, #core_modules, 1 do
       require("doom.core.settings").custom_options()
       -- Doom Nvim custom commands
       require("doom.core.settings").doom_commands()
-    elseif core_modules[i] == "config" then
-      -- Automatically install language DAP clients
-      require("doom.core.config").install_dap_clients(
-        require("doom.core.config.modules").modules.langs
-      )
     end
     log.debug(string.format("Successfully loaded 'doom.core.%s' module", core_modules[i]))
   else

--- a/lua/doom/modules/config/doom-dap-install.lua
+++ b/lua/doom/modules/config/doom-dap-install.lua
@@ -4,7 +4,6 @@ return function()
   -- Init dap-install
   local dap_install = require("dap-install")
   dap_install.setup({
-	  verbosely_call_debuggers = true,
 	  installation_path = vim.fn.stdpath("data") .. "/dapinstall/",
   })
 

--- a/lua/doom/modules/config/doom-dap-install.lua
+++ b/lua/doom/modules/config/doom-dap-install.lua
@@ -1,4 +1,11 @@
 return function()
+  -- Init dap-install
+  local dap_install = require("dap-install")
+  dap_install.setup({
+	  verbosely_call_debuggers = true,
+	  installation_path = vim.fn.stdpath("data") .. "/dapinstall/",
+  })
+
   local log = require("doom.extras.logging")
   local utils = require("doom.utils")
   local installed_clients = require("dap-install.api.debuggers").get_installed_debuggers()
@@ -14,11 +21,11 @@ return function()
     lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
 
     -- If the +debug flag exists and the language client is not installed yet
-    if lang_str:find("%+debug") and (not utils.has_value(installed_clients, lang .. "_dbg")) then
+    if lang_str:find("%+debug") and (not utils.has_value(installed_clients, lang)) then
       -- Try to install the client only if there is a client available for
       -- the language, oterwise raise a warning
-      if utils.has_value(available_clients, lang .. "_dbg") then
-        require("dap-install.tools.tool_install").install_debugger(lang .. "_dbg")
+      if utils.has_value(available_clients, lang) then
+        require('dap-install.core.install').install_debugger(lang)
       else
         log.warn(
           "The language "

--- a/lua/doom/modules/config/doom-dap-install.lua
+++ b/lua/doom/modules/config/doom-dap-install.lua
@@ -33,10 +33,8 @@ return function()
       local lang_str = lang
       lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
 
-      log.info(string.format('Checking DAP for %s , has override? ', lang, dap_lang_lookup[lang] ~= nil ))
       -- DAPInstall.nvim has different names for the DAPs so sometimes we need to lookup the correct DAP to install
       if dap_lang_lookup[lang] ~= nil then
-        log.info('Overwritting ' .. lang .. ' with ' .. string.format('%s', dap_lang_lookup[lang]))
         lang = dap_lang_lookup[lang]
       else
         lang = { lang }

--- a/lua/doom/modules/config/doom-dap-install.lua
+++ b/lua/doom/modules/config/doom-dap-install.lua
@@ -1,0 +1,31 @@
+return function()
+  local log = require("doom.extras.logging")
+  local utils = require("doom.utils")
+  local installed_clients = require("dap-install.api.debuggers").get_installed_debuggers()
+  -- NOTE: not all the clients follows the 'language_dbg' standard and this
+  --       can give some problems to us (maybe?)
+  local available_clients = vim.tbl_keys(require("dap-install.api.debuggers").get_debuggers())
+
+  local modules = require("doom.core.config.modules").modules
+  local langs = modules.langs
+
+  for _, lang in ipairs(langs) do
+    local lang_str = lang
+    lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
+
+    -- If the +debug flag exists and the language client is not installed yet
+    if lang_str:find("%+debug") and (not utils.has_value(installed_clients, lang .. "_dbg")) then
+      -- Try to install the client only if there is a client available for
+      -- the language, oterwise raise a warning
+      if utils.has_value(available_clients, lang .. "_dbg") then
+        require("dap-install.tools.tool_install").install_debugger(lang .. "_dbg")
+      else
+        log.warn(
+          "The language "
+            .. lang
+            .. ' does not have a DAP client, please remove the "+debug" flag'
+        )
+      end
+    end
+  end
+end

--- a/lua/doom/modules/config/doom-dap-install.lua
+++ b/lua/doom/modules/config/doom-dap-install.lua
@@ -1,4 +1,6 @@
 return function()
+  local log = require("doom.extras.logging")
+  local utils = require("doom.utils")
   -- Init dap-install
   local dap_install = require("dap-install")
   dap_install.setup({
@@ -6,33 +8,57 @@ return function()
 	  installation_path = vim.fn.stdpath("data") .. "/dapinstall/",
   })
 
-  local log = require("doom.extras.logging")
-  local utils = require("doom.utils")
-  local installed_clients = require("dap-install.api.debuggers").get_installed_debuggers()
-  -- NOTE: not all the clients follows the 'language_dbg' standard and this
-  --       can give some problems to us (maybe?)
-  local available_clients = vim.tbl_keys(require("dap-install.api.debuggers").get_debuggers())
+  local dap_lang_lookup = {
+    cpp = {'ccppr_vsc'},
+    c = {'ccppr_vsc'},
+    rust = {'ccppr_vsc'},
+    go = {'go_delve'},
+    javascript = { 'chrome', 'jsnode' },
+    typescript = { 'chrome', 'jsnode' },
+    ruby = {'ruby_vsc'}
+  }
 
-  local modules = require("doom.core.config.modules").modules
-  local langs = modules.langs
+  -- Iterates through langs and installs clients where possible
+  local install_dap_clients = function()
+    local installed_clients = require("dap-install.api.debuggers").get_installed_debuggers()
+    -- NOTE: not all the clients follows the 'language_dbg' standard and this
+    --       can give some problems to us (maybe?)
+    local available_clients = vim.tbl_keys(require("dap-install.api.debuggers").get_debuggers())
 
-  for _, lang in ipairs(langs) do
-    local lang_str = lang
-    lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
+    local modules = require("doom.core.config.modules").modules
+    local langs = modules.langs
 
-    -- If the +debug flag exists and the language client is not installed yet
-    if lang_str:find("%+debug") and (not utils.has_value(installed_clients, lang)) then
-      -- Try to install the client only if there is a client available for
-      -- the language, oterwise raise a warning
-      if utils.has_value(available_clients, lang) then
-        require('dap-install.core.install').install_debugger(lang)
+    for _, lang in ipairs(langs) do
+      local lang_str = lang
+      lang = lang:gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
+
+      -- DAPInstall.nvim has different names for the DAPs so sometimes we need to lookup the correct DAP to install
+      if utils.has_value(dap_lang_lookup, lang) then
+        lang = dap_lang_lookup[lang]
       else
-        log.warn(
-          "The language "
-            .. lang
-            .. ' does not have a DAP client, please remove the "+debug" flag'
-        )
+        lang = { lang }
+      end
+
+      -- Iterate over DAPs installing them one by one
+      for _, dap_name in ipairs(lang) do
+        -- If the +debug flag exists and the language client is not installed yet
+        if lang_str:find("%+debug") and (not utils.has_value(installed_clients, dap_name)) then
+
+          -- Try to install the client only if there is a client available for
+          -- the language, oterwise raise a warning
+          if utils.has_value(available_clients, dap_name) then
+            require('dap-install.core.install').install_debugger(dap_name)
+          else
+            log.warn(
+              "The language "
+                .. dap_name
+                .. ' does not have a DAP client, please remove the "+debug" flag'
+            )
+          end
+        end
       end
     end
   end
+
+  install_dap_clients()
 end

--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -425,7 +425,7 @@ packer.startup(function(use)
   use({
     "mfussenegger/nvim-dap",
     disable = disabled_dap,
-    event = "ColorScheme",
+    event = "BufWinEnter",
   })
 
   use({
@@ -437,6 +437,7 @@ packer.startup(function(use)
 
   use({
     "Pocco81/DAPInstall.nvim",
+    config = require("doom.modules.config.doom-dap-install"),
     disable = disabled_dap,
     after = "nvim-dap",
   })


### PR DESCRIPTION
The automatic installer had the same problem as #87 & #149.

Also it seems like the `ColourScheme` event wasn't triggering `nvim-dap` so I've removed lazy loading from it.  Let me know if there's another autocommand that would be more suitable. 

Additionally the api to install DAPs has changed so I've fixed that. 
