### PR TITLE
fix(dapui): open_on_start deprecated

### DIFF
--- a/lua/doom/modules/config/doom-dap-ui.lua
+++ b/lua/doom/modules/config/doom-dap-ui.lua
@@ -34,7 +34,6 @@ return function()
       position = "left", -- Can be "left" or "right"
     },
     tray = {
-      open_on_start = true,
       elements = {
         "repl",
       },


### PR DESCRIPTION
Following issue #136. Remove the second line containing the deprecated `open_on_start` field.