### PR TITLE
chore(nvim-tree): Update nvim-tree lsp_diagnostics config

### DIFF
--- a/lua/doom/modules/config/doom-tree.lua
+++ b/lua/doom/modules/config/doom-tree.lua
@@ -94,7 +94,15 @@ return function()
     -- updates the root directory of the tree on `DirChanged` (when your run `:cd` usually)
     update_cwd = true,
     -- show lsp diagnostics in the signcolumn
-    lsp_diagnostics = require("doom.core.functions").is_plugin_disabled("lsp") and false or true,
+    diagnostics = {
+	    enable = require("doom.core.functions").is_plugin_disabled("lsp") and false or true,
+	    icons = {
+		    hint = config.doom.lsp_hint,
+		    info = config.doom.lsp_information,
+		    warning = config.doom.lsp_warning,
+		    error = config.doom.lsp_error,
+	    },
+    },
     -- update the focused file on `BufEnter`, un-collapses the folders recursively until it finds the file
     update_focused_file = {
       -- enables the feature


### PR DESCRIPTION
Nvim-tree diagnostics section have been updated according to the commit: kyazdani42/nvim-tree.lua@94b8604.