### PR TITLE
Keybinding: Stay in visual select mode after indenting/unindenting

### DIFF
--- a/lua/doom/extras/keybindings/movement.lua
+++ b/lua/doom/extras/keybindings/movement.lua
@@ -95,6 +95,26 @@ mappings.map(
 )
 mappings.map("x", "J", ":move '>+1<CR>gv-gv", opts, "Editor", "select_left", "Move selection left")
 
+-- stay in visual mode after indenting with < or >
+mappings.map(
+  "v",
+  ">",
+  ">gv",
+  opts,
+  "Editor",
+  "stay_vselect_indent",
+  "Stay in visual mode after indenting a selection"
+)
+mappings.map(
+  "v",
+  "<",
+  "<gv",
+  opts,
+  "Editor",
+  "stay_vselect_deindent",
+  "Stay in visual mode after unindenting a selection"
+)
+
 -- get out of terminal insert mode into normal mode with Esc
 mappings.map(
   "t",


### PR DESCRIPTION
Hello!

I use < and > to indent/unindent quite often and when using them in visual select mode I usually bind them to <gv and >gv to stay in visual select mode after doing the indentation. Since I saw this was used in doom-emacs as well I thought I'd check if this is of interest?

Regards :)