### PR TITLE
Feature/pin packer dependencies

### DIFF
--- a/contribute/README.md
+++ b/contribute/README.md
@@ -37,3 +37,22 @@ These are the folders used by this docker image, they will be auto generated whe
 `contribute/doom-nvim-contrib/` - Git worktree for doom-nvim contributions
 `contribute/local-share-nvim/` - Stores the data from `~/.local/share/nvim/` 
 `contribute/workspace/` - Directory to store test files and project that you want to test your changes upon
+
+## Pinned Dependencies `./update_dependencies.sh`
+
+This script parses the `lua/doom/modules/init.lua` file and pins each plugin to the latest commit in the default branch.  
+We should update these dependencies with each release of doom-nvim, and test everything working together to ensure a stable experience for users.
+Pinned/frozen dependencies can be disabled using the `freeze_dependencies` configuration option in `doom_config.lua`.
+
+### How to use
+
+Run the following command in the root of the neovim folder.
+```bash
+cd contribute && ./update_dependencies.sh`
+```
+
+### Issues
+- The `commit = pin_commit(...)` line must be immediately after the package name
+- It does not work if the dependency also has the `branch = '...'` option.  These will have to be updated manually.
+- It does not work if there is custom logic for determining pinned commits (such as depending on neovim version).  These will have to be updated manually.
+- Github API ratelimits requests, you can specify a GITHUB_API_KEY environment variable (docs)[https://docs.github.com/en/developers/apps/building-oauth-apps], or you can use a VPN to change IP addresses.

--- a/contribute/update_dependencies.sh
+++ b/contribute/update_dependencies.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# This script updates pinned dependencies in ../lua/doom/modules/init.lua
+# It uses grep to find instances of packer.use, uses the repository url to fetch the latest commit sha, and modifies the values
+# Dependencies
+# perl -- used for Regexing the repository <account>/<repo_name> with capture groups to extract inner text
+# grep -- Used for regexing the use({}) block with line numbers
+# 
+
+index=0
+repo_regex='"([^"]+)"'
+pin_commit_regex='pin_commit[(][^()]*[)]'
+
+repo=''
+latest_commit=''
+
+while read -r line; do
+  if [[ $index -eq 1 ]]; then
+    # Get the repository name as `<username>/reponame`
+    if [[ $line =~ $repo_regex ]]; then # Regex $line against $repo_regex
+      repo="${BASH_REMATCH[1]}" # Get first capture group
+      echo ""
+      echo "Updating $repo:"
+
+      # Sometimes the github api requests will fail, in which case we need to re-try after a delay.
+      while [ -z "$latest_commit" ]; do
+        # Get the commit sha from github
+        api_result=`curl -s \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/$repo/commits?per_page=1`
+
+        is_array=`echo $api_result | jq -r 'if type=="array" then "yes" else "no" end'`
+
+        # If there's an error, log it and wait 30 seconds
+        if [ "$is_array" = "no" ]; then
+          echo "- Github API Error: $( echo "$api_result" | jq -r .message )"
+          echo "- Waiting 30 seconds before trying again..."
+          sleep 30
+        else
+          latest_commit=`echo $api_result | jq -r .[0].sha`
+        fi
+
+      done
+    else
+      echo " - ERROR: No repo name for $line :("
+    fi
+  fi
+
+  if [[ $index -eq 2 ]]; then # 
+    if [ ! -z "$repo" ] && [ ! -z "$latest_commit" ] && [[ $line =~ $pin_commit_regex ]]; then 
+      line_number=`echo $line | awk -F "-" '{print $1}'`
+      sed -r -i -- "${line_number}s/pin_commit[(][^()]*[)]/pin_commit('${latest_commit}')/" "../lua/doom/modules/init.lua"
+      echo " - Updated to $latest_commit"
+    else
+      echo " - ERROR: Did not update $repo because \`commit = pin_commit('...')\` was not immediately after the repo name."
+    fi
+  fi
+
+  let index+=1
+  if [[ $line == '--' ]]; then
+    sleep 5
+    index=0
+    repo=''
+    latest_commit=''
+  fi
+done < <(grep -n "use\(\{" -A 2 -E ../lua/doom/modules/init.lua)
+
+

--- a/contribute/update_dependencies.sh
+++ b/contribute/update_dependencies.sh
@@ -9,7 +9,7 @@
 
 index=0
 repo_regex='"([^"]+)"'
-pin_commit_regex='pin_commit[(][^()]*[)]'
+pin_commit_regex='commit = pin_commit[(][^()]*[)]'
 
 repo=''
 latest_commit=''
@@ -49,10 +49,10 @@ while read -r line; do
   if [[ $index -eq 2 ]]; then # 
     if [ ! -z "$repo" ] && [ ! -z "$latest_commit" ] && [[ $line =~ $pin_commit_regex ]]; then 
       line_number=`echo $line | awk -F "-" '{print $1}'`
-      sed -r -i -- "${line_number}s/pin_commit[(][^()]*[)]/pin_commit('${latest_commit}')/" "../lua/doom/modules/init.lua"
+      sed -r -i -- "${line_number}s/commit = pin_commit[(][^()]*[)]/commit = pin_commit('${latest_commit}')/" "../lua/doom/modules/init.lua"
       echo " - Updated to $latest_commit"
     else
-      echo " - ERROR: Did not update $repo because \`commit = pin_commit('...')\` was not immediately after the repo name."
+      echo " - ERROR: Did not update $repo because \`commit = pin_commit('...')\` was not immediately after the repo name or there is custom logic for determining the pinned commit.  Please update this entry manually."
     fi
   fi
 

--- a/doom_config.lua
+++ b/doom_config.lua
@@ -14,6 +14,10 @@ M.source = debug.getinfo(1, "S").source:sub(2)
 
 M.config = {
   doom = {
+    -- Pins plugins to a commit sha to prevent breaking changes
+    -- @default = true
+    freeze_dependencies = true,
+
     -- Autosave
     -- false : Disable autosave
     -- true  : Enable autosave

--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -8,7 +8,7 @@ local use_floating_win_packer = require("doom.core.config").config.doom.use_floa
 
 -- Freeze dependencies and helper function for clean code
 local freeze_dependencies = require("doom.core.config").config.doom.freeze_dependencies
-local pin_commit = function(commit_sha) freeze_dependencies and commit_sha or nil end
+local pin_commit = function(commit_sha) return freeze_dependencies and commit_sha or nil end
 
 ---- Packer Bootstrap ---------------------------
 -------------------------------------------------
@@ -94,7 +94,7 @@ packer.startup(function(use)
   local disabled_neorg = is_plugin_disabled("neorg")
   use({
     "nvim-neorg/neorg",
-    commit = pin_commit('592fb0c9c220ca53238e6de7685c3151fe3a3085'),
+    commit = pin_commit('2fdce1aaf542d930df92d394e646f9bafe4e41a3'),
     branch = "unstable",
     config = require("doom.modules.config.doom-neorg"),
     disable = disabled_neorg,
@@ -445,7 +445,7 @@ packer.startup(function(use)
   -- Manage Language serverss with ease.
   use({
     "MordechaiHadad/nvim-lspmanager",
-    commit = pin_commit('9d0ecc5010bca0a78624e99bfffb64cab5ae390f'),
+    commit = pin_commit('817998fb83ad8c05e9a315d0a6d25fddae56fe23'),
     branch = "dev",
     config = require("doom.modules.config.doom-lspmanager"),
     disable = disabled_lsp,

--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -394,6 +394,7 @@ packer.startup(function(use)
     requires = {
       {
         "L3MON4D3/LuaSnip",
+        commit = pin_commit('a54b21aee0423dbdce121c858ad6a88a58ef6e0f'),
         event = "BufReadPre",
         wants = "friendly-snippets",
         config = require("doom.modules.config.doom-luasnip"),
@@ -402,6 +403,7 @@ packer.startup(function(use)
       },
       {
         "windwp/nvim-autopairs",
+        commit = pin_commit('e6b1870cd2e319f467f99188f99b1c3efc5824d2'),
         config = require("doom.modules.config.doom-autopairs"),
         disable = disabled_autopairs,
         event = "BufReadPre",

--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -6,6 +6,10 @@
 local is_plugin_disabled = require("doom.utils").is_plugin_disabled
 local use_floating_win_packer = require("doom.core.config").config.doom.use_floating_win_packer
 
+-- Freeze dependencies and helper function for clean code
+local freeze_dependencies = require("doom.core.config").config.doom.freeze_dependencies
+local pin_commit = function(commit_sha) freeze_dependencies and commit_sha or nil end
+
 ---- Packer Bootstrap ---------------------------
 -------------------------------------------------
 local packer_path = vim.fn.stdpath("data") .. "/site/pack/packer/opt/packer.nvim"
@@ -64,20 +68,24 @@ packer.startup(function(use)
   })
   use({
     "JoosepAlviste/nvim-ts-context-commentstring",
+    commit = pin_commit('a2283cfc9f4aa892349004153ab54dfe8911241c'),
     after = "nvim-treesitter",
   })
   use({
     "nvim-treesitter/nvim-tree-docs",
+    commit = pin_commit('10a49cef11fee8b2f7bd9f6e4d118caa3d43b28e'),
     after = "nvim-treesitter",
   })
   use({
     "windwp/nvim-ts-autotag",
+    commit = pin_commit('80d427af7b898768c8d8538663d52dee133da86f'),
     after = "nvim-treesitter",
   })
 
   -- Aniseed, required by some treesitter modules
   use({
     "Olical/aniseed",
+    commit = pin_commit('4bb3a4c1a1e329ebefa7ff022f7b3947770f7f26'),
     module_pattern = "aniseed",
   })
 
@@ -85,6 +93,7 @@ packer.startup(function(use)
   local disabled_neorg = is_plugin_disabled("neorg")
   use({
     "nvim-neorg/neorg",
+    commit = pin_commit('592fb0c9c220ca53238e6de7685c3151fe3a3085'),
     branch = "unstable",
     config = require("doom.modules.config.doom-neorg"),
     disable = disabled_neorg,
@@ -95,6 +104,7 @@ packer.startup(function(use)
   local disabled_sessions = is_plugin_disabled("auto-session")
   use({
     "folke/persistence.nvim",
+    commit = pin_commit('77cf5a6ee162013b97237ff25450080401849f85'),
     config = require("doom.modules.config.doom-persistence"),
     -- event = "VimEnter",
     disable = disabled_sessions,
@@ -107,6 +117,7 @@ packer.startup(function(use)
   local disabled_dashboard = is_plugin_disabled("dashboard")
   use({
     "glepnir/dashboard-nvim",
+    commit = pin_commit('ba98ab86487b8eda3b0934b5423759944b5f7ebd'),
     config = require("doom.modules.config.doom-dashboard"),
     disable = disabled_dashboard,
   })
@@ -115,12 +126,14 @@ packer.startup(function(use)
   local disabled_doom_themes = is_plugin_disabled("doom-themes")
   use({
     "GustavoPrietoP/doom-themes.nvim",
+    commit = pin_commit('03d417d3eab71c320744f8da22251715ba6cee53'),
     disable = disabled_doom_themes,
   })
 
   -- Development icons
   use({
     "kyazdani42/nvim-web-devicons",
+    commit = pin_commit('ee101462d127ed6a5561ce9ce92bfded87d7d478'),
     module = "nvim-web-devicons",
   })
 
@@ -129,6 +142,7 @@ packer.startup(function(use)
     and require("doom.core.config").config.doom.use_netrw
   use({
     "kyazdani42/nvim-tree.lua",
+    commit = pin_commit('c4ecf4416bc0a5f5b2ffacc18476a776953f9e03'),
     requires = "nvim-web-devicons",
     config = require("doom.modules.config.doom-tree"),
     disable = disabled_tree,
@@ -146,6 +160,7 @@ packer.startup(function(use)
   local disabled_ranger = is_plugin_disabled("ranger")
   use({
     "francoiscabrol/ranger.vim",
+    commit = pin_commit('91e82debdf566dfaf47df3aef0a5fd823cedf41c'),
     requires = "rbgrouleff/bclose.vim",
     disable = disabled_ranger,
   })
@@ -155,6 +170,7 @@ packer.startup(function(use)
   local disabled_statusline = is_plugin_disabled("statusline")
   use({
     "NTBBloodbath/galaxyline.nvim",
+    commit = pin_commit('7b812cfddfcac7d9031e2f8e03f2b71fe8b2558d'),
     config = require("doom.modules.config.doom-eviline"),
     disable = disabled_statusline,
   })
@@ -164,6 +180,7 @@ packer.startup(function(use)
   local disabled_tabline = is_plugin_disabled("tabline")
   use({
     "akinsho/bufferline.nvim",
+    commit = pin_commit('58e8d9b7c9aaf603f1093f808628b5a8f03493af'),
     config = require("doom.modules.config.doom-bufferline"),
     disable = disabled_tabline,
     event = "BufWinEnter",
@@ -174,6 +191,7 @@ packer.startup(function(use)
   local disabled_terminal = is_plugin_disabled("terminal")
   use({
     "akinsho/toggleterm.nvim",
+    commit = pin_commit('9cdc5e9bb2affb25af5d4bda930738144193bd36'),
     config = require("doom.modules.config.doom-toggleterm"),
     disable = disabled_terminal,
     module = { "toggleterm", "toggleterm.terminal" },
@@ -185,6 +203,7 @@ packer.startup(function(use)
   local disabled_outline = is_plugin_disabled("symbols")
   use({
     "simrat39/symbols-outline.nvim",
+    commit = pin_commit('552b67993ed959993279e0b0f8a1da9f3c5e6fc0'),
     config = require("doom.modules.config.doom-symbols"),
     disable = disabled_outline,
     cmd = {
@@ -199,6 +218,7 @@ packer.startup(function(use)
   local disabled_minimap = is_plugin_disabled("minimap")
   use({
     "wfxr/minimap.vim",
+    commit = pin_commit('5c54258d34b8ae4be70a8fbc09b400eb7be0bee8'),
     disable = disabled_minimap,
     cmd = {
       "Minimap",
@@ -213,6 +233,7 @@ packer.startup(function(use)
   local disabled_whichkey = is_plugin_disabled("which-key")
   use({
     "folke/which-key.nvim",
+    commit = pin_commit('d3032b6d3e0adb667975170f626cb693bfc66baa'),
     opt = true,
     config = require("doom.modules.config.doom-whichkey"),
     disable = disabled_whichkey,
@@ -222,13 +243,15 @@ packer.startup(function(use)
   local disabled_show_registers = is_plugin_disabled("show_registers")
   use({
     "tversteeg/registers.nvim",
+    commit = pin_commit('4d1f3525c6f9be4297e99e6aed515af3677d7241'),
     disable = disabled_show_registers,
   })
 
   -- Distraction free environment
   local disabled_zen = is_plugin_disabled("zen")
   use({
-    "kdav5758/TrueZen.nvim",
+    "Pocco81/TrueZen.nvim",
+    commit = pin_commit('508b977d71650da5c9243698614a9a1416f116d4'),
     config = require("doom.modules.config.doom-zen"),
     disable = disabled_zen,
     module = "true-zen",
@@ -239,6 +262,7 @@ packer.startup(function(use)
   local disabled_illuminate = is_plugin_disabled("illuminated")
   use({
     "RRethy/vim-illuminate",
+    commit = pin_commit('084b012ce5bc1bf302b69eb73562146afe0a9756'),
     setup = function()
       vim.g.Illuminate_ftblacklist = {
         "help",
@@ -260,16 +284,19 @@ packer.startup(function(use)
   -----]]--------------[[-----
   use({
     "nvim-lua/plenary.nvim",
+    commit = pin_commit('96e821e8001c21bc904d3c15aa96a70c11462c5f'),
     module = "plenary",
   })
   use({
     "nvim-lua/popup.nvim",
+    commit = pin_commit('f91d80973f80025d4ed00380f2e06c669dfda49d'),
     module = "popup",
   })
 
   local disabled_telescope = is_plugin_disabled("telescope")
   use({
     "nvim-telescope/telescope.nvim",
+    commit = pin_commit('3b9ac8edba8c1b4053c7f6ac8a4e78969cec66dd'),
     cmd = "Telescope",
     module = "telescope",
     requires = {
@@ -281,6 +308,7 @@ packer.startup(function(use)
   })
   use({
     "lazytanuki/nvim-mapper",
+    commit = pin_commit('e11e852bafa41a4a2c160fcd2d38779add423db9'),
     config = function()
       local doom_root, sep = require("doom.core.system").doom_root, require("doom.core.system").sep
       require("nvim-mapper").setup({
@@ -307,6 +335,7 @@ packer.startup(function(use)
   local disabled_gitsigns = is_plugin_disabled("gitsigns")
   use({
     "lewis6991/gitsigns.nvim",
+    commit = pin_commit('d12442a924dc431467149f1fcb33e1c648116803'),
     config = require("doom.modules.config.doom-gitsigns"),
     disable = disabled_gitsigns,
     requires = "plenary.nvim",
@@ -317,6 +346,7 @@ packer.startup(function(use)
   local disabled_neogit = is_plugin_disabled("neogit")
   use({
     "TimUntersberger/neogit",
+    commit = pin_commit('f214200d71391dfc5763769ca1120e3aa5902c2d'),
     config = function()
       require("neogit").setup({})
     end,
@@ -329,6 +359,7 @@ packer.startup(function(use)
   local disabled_lazygit = is_plugin_disabled("lazygit")
   use({
     "kdheepak/lazygit.nvim",
+    commit = pin_commit('b1ebb53902a4f5d8c565f7485d4e57d937f89b91'),
     requires = "plenary.nvim",
     disable = disabled_lazygit,
     cmd = { "LazyGit", "LazyGitConfig" },
@@ -341,6 +372,7 @@ packer.startup(function(use)
   -- Built-in LSP Config
   use({
     "neovim/nvim-lspconfig",
+    commit = pin_commit('9314d0a8da0f5ccd700d8a1fa699949a95971420'),
     config = require("doom.modules.config.doom-lspconfig"),
     disable = disabled_lsp,
   })
@@ -356,6 +388,7 @@ packer.startup(function(use)
   -- can be disabled to use your own completion plugin
   use({
     "hrsh7th/nvim-cmp",
+    commit = pin_commit('669803b9ffb31b3963afb4f05c1622fc48ab65cb'),
     wants = { "LuaSnip" },
     requires = {
       {
@@ -379,26 +412,31 @@ packer.startup(function(use)
   })
   use({
     "hrsh7th/cmp-nvim-lua",
+    commit = pin_commit('d276254e7198ab7d00f117e88e223b4bd8c02d21'),
     disable = disabled_lsp,
     after = "nvim-cmp",
   })
   use({
     "hrsh7th/cmp-nvim-lsp",
+    commit = pin_commit('accbe6d97548d8d3471c04d512d36fa61d0e4be8'),
     disable = disabled_lsp,
     after = "nvim-cmp",
   })
   use({
     "hrsh7th/cmp-path",
+    commit = pin_commit('97661b00232a2fe145fe48e295875bc3299ed1f7'),
     disable = disabled_lsp,
     after = "nvim-cmp",
   })
   use({
     "hrsh7th/cmp-buffer",
+    commit = pin_commit('5dde5430757696be4169ad409210cf5088554ed6'),
     disable = disabled_lsp,
     after = "nvim-cmp",
   })
   use({
     "saadparwaiz1/cmp_luasnip",
+    commit = pin_commit('16832bb50e760223a403ffa3042859845dd9ef9d'),
     disable = disabled_lsp,
     after = "nvim-cmp",
   })
@@ -406,6 +444,7 @@ packer.startup(function(use)
   -- Manage Language serverss with ease.
   use({
     "MordechaiHadad/nvim-lspmanager",
+    commit = pin_commit('9d0ecc5010bca0a78624e99bfffb64cab5ae390f'),
     branch = "dev",
     config = require("doom.modules.config.doom-lspmanager"),
     disable = disabled_lsp,
@@ -414,6 +453,7 @@ packer.startup(function(use)
   -- Show function signature when you type
   use({
     "ray-x/lsp_signature.nvim",
+    commit = pin_commit('6469c55ce7afc8cdfb6d0b6b3fbfd331bcc26410'),
     config = require("doom.modules.config.doom-lsp-signature"),
     after = "nvim-lspconfig",
     event = "InsertEnter",
@@ -422,6 +462,7 @@ packer.startup(function(use)
   -- Setup for Lua development in Neovim
   use({
     "folke/lua-dev.nvim",
+    commit = pin_commit('6a7abb62af1b6a4411a3f5ea5cf0cb6b47878cc0'),
     disable = disabled_lsp,
     module = "lua-dev",
   })
@@ -432,12 +473,14 @@ packer.startup(function(use)
   local disabled_dap = is_plugin_disabled("dap")
   use({
     "mfussenegger/nvim-dap",
+    commit = pin_commit('dd778f65dc95323f781f291fb7c5bf3c17d057b1'),
     disable = disabled_dap,
     event = "BufWinEnter",
   })
 
   use({
     "rcarriga/nvim-dap-ui",
+    commit = pin_commit('547635e7ba1dace13189386c98c3c7b064d585c4'),
     config = require("doom.modules.config.doom-dap-ui"),
     disable = disabled_dap,
     after = "nvim-dap",
@@ -445,6 +488,7 @@ packer.startup(function(use)
 
   use({
     "Pocco81/DAPInstall.nvim",
+    commit = pin_commit('b95e9ad32f1c45855b9965b545c86e82d8a827ac'),
     config = require("doom.modules.config.doom-dap-install"),
     disable = disabled_dap,
     after = "nvim-dap",
@@ -458,6 +502,7 @@ packer.startup(function(use)
   local disabled_suda = is_plugin_disabled("suda")
   use({
     "lambdalisue/suda.vim",
+    commit = pin_commit('0290c93c148a14eab2b661a1933003d86436f6ec'),
     disable = disabled_suda,
     cmd = { "SudaRead", "SudaWrite" },
   })
@@ -467,6 +512,7 @@ packer.startup(function(use)
   local disabled_formatter = is_plugin_disabled("formatter")
   use({
     "lukas-reineke/format.nvim",
+    commit = pin_commit('c46ab8b46100e26fce4d6ce69a94d4cea8b9f4d7'),
     config = require("doom.modules.config.doom-format"),
     disable = disabled_formatter,
     cmd = { "Format", "FormatWrite" },
@@ -476,6 +522,7 @@ packer.startup(function(use)
   local disabled_linter = is_plugin_disabled("linter")
   use({
     "mfussenegger/nvim-lint",
+    commit = pin_commit('b1467a01f48736b309e0e274c032b69051740c08'),
     config = require("doom.modules.config.doom-lint"),
     disable = disabled_linter,
     module = "lint",
@@ -485,6 +532,7 @@ packer.startup(function(use)
   local disabled_indent_lines = is_plugin_disabled("indentlines")
   use({
     "lukas-reineke/indent-blankline.nvim",
+    commit = pin_commit('252797e7a96fa4f7c6ccdcdff3f488fdd48b1d09'),
     config = require("doom.modules.config.doom-blankline"),
     disable = disabled_indent_lines,
     event = "ColorScheme",
@@ -494,6 +542,7 @@ packer.startup(function(use)
   local disabled_editorconfig = is_plugin_disabled("editorconfig")
   use({
     "editorconfig/editorconfig-vim",
+    commit = pin_commit('3078cd10b28904e57d878c0d0dab42aa0a9fdc89'),
     disable = disabled_editorconfig,
   })
 
@@ -502,6 +551,7 @@ packer.startup(function(use)
   local disabled_kommentary = is_plugin_disabled("kommentary")
   use({
     "b3nj5m1n/kommentary",
+    commit = pin_commit('8f1cd74ad28de7d7c4fda5d8e8557ff240904b42'),
     disable = disabled_kommentary,
     event = "BufWinEnter",
   })
@@ -510,11 +560,13 @@ packer.startup(function(use)
   -- Lua 5.1 docs
   use({
     "milisims/nvim-luaref",
+    commit = pin_commit('dc40d606549db7df1a6e23efa743c90c178333d4'),
     disable = disabled_contrib,
   })
   -- LibUV docs
   use({
     "nanotee/luv-vimdocs",
+    commit = pin_commit('ddcd5ef0100e66da0d4a709391a9b3e9453f19a1'),
     disable = disabled_contrib,
   })
 
@@ -525,6 +577,7 @@ packer.startup(function(use)
   local disabled_colorizer = is_plugin_disabled("colorizer")
   use({
     "norcalli/nvim-colorizer.lua",
+    commit = pin_commit('36c610a9717cc9ec426a07c8e6bf3b3abcb139d6'),
     config = require("doom.modules.config.doom-colorizer"),
     disable = disabled_colorizer,
     event = "ColorScheme",
@@ -535,6 +588,7 @@ packer.startup(function(use)
   local disabled_restclient = is_plugin_disabled("restclient")
   use({
     "NTBBloodbath/rest.nvim",
+    commit = pin_commit('5130e59f680df56f22bd8cc41da422f9a05580c5'),
     requires = "plenary.nvim",
     config = function()
       require("rest-nvim").setup()
@@ -546,6 +600,7 @@ packer.startup(function(use)
   local disabled_range_highlight = is_plugin_disabled("range-highlight")
   use({
     "winston0410/range-highlight.nvim",
+    commit = pin_commit('8b5e8ccb3460b2c3675f4639b9f54e64eaab36d9'),
     requires = {
       { "winston0410/cmd-parser.nvim", module = "cmd-parser" },
     },
@@ -559,6 +614,7 @@ packer.startup(function(use)
   local disabled_firenvim = is_plugin_disabled("firenvim")
   use({
     "glacambre/firenvim",
+    commit = pin_commit('eb3abef4520d17dbd9957f5d23ada74b853133e4'),
     disable = disabled_firenvim,
     run = function()
       vim.fn["firenvim#install"](0)
@@ -569,6 +625,7 @@ packer.startup(function(use)
   local disabled_todo = is_plugin_disabled("todo_comments")
   use({
     "folke/todo-comments.nvim",
+    commit = pin_commit('9983edc5ef38c7a035c17c85f60ee13dbd75dcc8'),
     requires = "nvim-lua/plenary.nvim",
     config = require("doom.modules.config.doom-todo"),
     disable = disabled_todo,
@@ -578,6 +635,7 @@ packer.startup(function(use)
   local disabled_trouble = is_plugin_disabled("trouble")
   use({
     "folke/trouble.nvim",
+    commit = pin_commit('756f09de113a775ab16ba6d26c090616b40a999d'),
     cmd = { "Trouble", "TroubleClose", "TroubleRefresh", "TroubleToggle" },
     requires = "kyazdani42/nvim-web-devicons",
     config = require("doom.modules.config.doom-trouble"),
@@ -587,6 +645,7 @@ packer.startup(function(use)
   local disabled_superman = is_plugin_disabled("superman")
   use({
     "jez/vim-superman",
+    commit = pin_commit('19d307446576d9118625c5d9d3c7a4c9bec5571a'),
     cmd = "SuperMan",
     disable = disabled_superman,
   })

--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -61,6 +61,7 @@ packer.startup(function(use)
   -- Tree-Sitter
   use({
     "nvim-treesitter/nvim-treesitter",
+    commit = vim.fn.has("nvim-0.6.0") == 1 and pin_commit('fe4e4aa286ba14e949948ef6e826d69c63048cdb') or pin_commit('47cfda2c6711077625c90902d7722238a8294982'),
     opt = true,
     run = ":TSUpdate",
     branch = vim.fn.has("nvim-0.6.0") == 1 and "master" or "0.5-compat",


### PR DESCRIPTION
This PR addresses #183 by pinning all packer dependencies to the current latest version from github.
I also made a script to automate this process which works by running `./update_dependencies.sh` from within `doom-nvim/contribute/`.  It uses a mixture of grep and perl to find the dependencies, `curl` and `jq` to query the latest versions using the github API and `sed` to modify `lua/doom/modules/init.lua`.

There are a couple of big caveats and I think this should be re-written in LUA but it does 95% of the work for you for now which is good.

## Caveats
- The github API is ratelimited, because there are so many dependencies I've had to switch nodes on my VPN to finish running the script.  (another workaround is to provide a Github API key).
- The github API is slow the script takes quite a while to run because everything is synchronous.
- Parsing the data with grep/perl and sed sucks and is prone to failure, right now the `commit = pin_commit` has to be on the line after the repository name
- Doesn't handle all edge cases, right now it only updates using the default main/master branch.  I've just manually updated these myself.
- Doesn't handle plugin dependencies i.e. if a plugin has:
```lua
  use({
    "hrsh7th/nvim-cmp",
    commit = pin_commit('669803b9ffb31b3963afb4f05c1622fc48ab65cb'),
    wants = { "LuaSnip" },
    requires = {
      {
        "L3MON4D3/LuaSnip",
        event = "BufReadPre",
        wants = "friendly-snippets",
        config = require("doom.modules.config.doom-luasnip"),
        disable = disabled_snippets,
        requires = { "rafamadriz/friendly-snippets" },
      },
      {
        "windwp/nvim-autopairs",
        config = require("doom.modules.config.doom-autopairs"),
        disable = disabled_autopairs,
        event = "BufReadPre",
      },
    },
    config = require("doom.modules.config.doom-cmp"),
    disable = disabled_lsp,
    event = "InsertEnter",
  })
```

## Future Solution
I don't think it's worth fixing these issues just yet because it does automate most of the work for you and it'd be good to get the release out.  I think the right way to do this is in lua, I could use treesitter queries to find repositories that need to be updated, fetch the latest version using `git fetch` and then push the changes into a quickfix buffer.  I think this would be good to incorporate into a `contributor` module that includes the work for the doom-nvim-contrib docker image.

> Also if you merge #206 first I'll add documentation for this script inside of `contribute/README.md`