### PR TITLE
LSPManager: Fix bug with overlapping LSPs and add multiple overrides

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -504,7 +504,7 @@ can use the packer's `config` field, e.g.
 [Language Server Protocols](https://microsoft.github.io/language-server-protocol/) is installed as a plugin.
 
 To easily install language servers and without having to do it system-wide or having to
-manually configure servers, Doom Nvim makes use of [kabouzeid/nvim-lspinstall](https://github.com/kabouzeid/nvim-lspinstall).
+manually configure servers, Doom Nvim makes use of [MordechaiHadad/nvim-lspmanager](https://github.com/MordechaiHadad/nvim-lspmanager).
 
 To enable the language server for a certain programming language and automatically
 install it, just append a `+lsp` flag at the end of the language field in your `doom_modules.lua`,
@@ -518,10 +518,18 @@ local doom = {
 }
 ```
 
-> **NOTE**: You can see a list of currently supported languages at [bundled installers](https://github.com/kabouzeid/nvim-lspinstall#bundled-installers).
+You can also override or add additional LSPs for a language using the `+lsp(OVERRIDE)` syntax.
 
-> **NOTE**: If you want a different language server, you can override the name using the following syntax `+lsp(OVERRIDE_LSP_NAME)`
-Where `OVERRIDE_LSP_NAME` is a different option at [bundled installers](https://github.com/kabouzeid/nvim-lspinstall).
+```lua
+local doom = {
+  langs = {
+    'html +lsp(html, tailwindcss)' -- Enable extra LSPs for a language
+    'vue +lsp(volar)' -- Or override the default
+  }
+}
+```
+
+> **NOTE**: You can see a list of currently supported languages at [bundled installers](https://github.com/MordechaiHadad/nvim-lspmanager#supported-language-servers).
 
 ### Binding keys
 

--- a/lua/doom/modules/config/doom-lspmanager.lua
+++ b/lua/doom/modules/config/doom-lspmanager.lua
@@ -24,6 +24,7 @@ return function()
     elixir = { "elixirls" },
     haskell = { "hls" },
     vue = { "vuels" },
+    config = { "jsonls" }
   }
 
   -- Snippets support
@@ -73,10 +74,10 @@ return function()
       -- Get LSP override +lsp(<override>) if it exists
       local lsp_override = lang:match("+lsp%((.+)%)")
       -- Array of lsps to ensure are installed
-      local lang_lsps = lsp_override ~= nil 
+      local lang_lsps = lsp_override ~= nil
         and vim.split(lsp_override, ',')
-        or servers[lang_name] ~= nil 
-          and servers[lang_name] 
+        or servers[lang_name] ~= nil
+          and servers[lang_name]
           or nil
 
       local should_install_lsp = lang:find('+lsp')
@@ -97,14 +98,14 @@ return function()
     end
 
     -- Uninstall all LSPs that shouldn't be installed
-    for i, server in ipairs(available_servers) do
+    for _, server in ipairs(available_servers) do
       if utils.has_value(ensure_installed, server) == false and utils.has_value(installed_servers, server) then
         lspmanager.uninstall(server)
       end
     end
 
     -- Install all LSPs that should be installed
-    for i, server in ipairs(ensure_installed) do
+    for _, server in ipairs(ensure_installed) do
       if utils.has_value(installed_servers, server) == false then
         lspmanager.install(server)
       end

--- a/lua/doom/modules/config/doom-lspmanager.lua
+++ b/lua/doom/modules/config/doom-lspmanager.lua
@@ -60,7 +60,13 @@ return function()
   -- Load langs from doom_modules and install servers with +lsp flag
   local function install_servers()
     local installed_servers = lspmanager.installed_servers()
-    local available_servers = lspmanager.available_servers()
+    -- Flatten the array of default servers.  Default servers will be automatically uninstalled if no +lsp flag is provided.
+    local default_servers = {}
+    for _, lang_servers in pairs(servers) do
+      for _, lsp_name in ipairs(lang_servers) do
+        table.insert(default_servers, lsp_name)
+      end
+    end
 
     local modules = require("doom.core.config.modules").modules
     local langs = modules.langs
@@ -97,17 +103,17 @@ return function()
       end
     end
 
-    -- Uninstall all LSPs that shouldn't be installed
-    for _, server in ipairs(available_servers) do
-      if utils.has_value(ensure_installed, server) == false and utils.has_value(installed_servers, server) then
-        lspmanager.uninstall(server)
+    -- Uninstall all (default) LSPs that shouldn't be installed
+    for _, lsp_name in ipairs(default_servers) do
+      if utils.has_value(ensure_installed, lsp_name) == false and utils.has_value(installed_servers, lsp_name) then
+        lspmanager.uninstall(lsp_name)
       end
     end
 
     -- Install all LSPs that should be installed
-    for _, server in ipairs(ensure_installed) do
-      if utils.has_value(installed_servers, server) == false then
-        lspmanager.install(server)
+    for _, lsp_name in ipairs(ensure_installed) do
+      if utils.has_value(installed_servers, lsp_name) == false then
+        lspmanager.install(lsp_name)
       end
     end
   end

--- a/lua/doom/modules/config/doom-lspmanager.lua
+++ b/lua/doom/modules/config/doom-lspmanager.lua
@@ -61,11 +61,6 @@ return function()
     local installed_servers = lspmanager.installed_servers()
     local available_servers = lspmanager.available_servers()
 
-    print("Installed servers")
-    for _, s in ipairs(installed_servers) do
-      print(s)
-    end
-
     local modules = require("doom.core.config.modules").modules
     local langs = modules.langs
 
@@ -153,7 +148,6 @@ return function()
 
     local installed_servers = lspmanager.installed_servers()
     for _, server in pairs(installed_servers) do
-      print('Setting up server '..server)
       -- Configure sumneko for neovim lua development
       if server == "sumneko_lua" then
         nvim_lsp.sumneko_lua.setup(lua_lsp)


### PR DESCRIPTION
I have re-written the auto install portion of the LSP to address some bugs and add more features

## Improvements
- Previously if two languages used the same LSP but only one had the `+lsp` flag, it would install and uninstall it at the same time causing an error (this was an issue with both javascript and typescript using `tsserver` LSP).
- Supports adding more default LSPs down the line
- I also added the ability to add multiple LSP overrides, such as the documented example in `getting_started.md`.

## How it works
- First determine all LSPs that need to be installed
- Determine which LSPs should be uninstalled
- Uninstall all the LSPs that ARE installed but shouldn't be (not in the ensure_installed) array.
- Install all LSPs that aren't installed but should be (not in the ensure_installed) array.

## Feedback Wanted
This will automatically uninstall any LSPs that are not specified in `doom.langs` of `doom_modules`.  This means if a user runs `:LspInstall` on a non-default language server it will be uninstalled next load of doom-nvim.  Is there a way we can show a warning when a user runs this command?  I think now that you can specify multiple LSPs overrides for a language we should encourage users to do that.  Alternatively I can add logic to automatically uninstall LSPs but only if they're default.