### PR TITLE
Added debugging keybindings

### DIFF
--- a/lua/doom/extras/keybindings/init.lua
+++ b/lua/doom/extras/keybindings/init.lua
@@ -1053,6 +1053,31 @@ utils.map(
 -- debugging
 utils.map(
   "n",
+  "<leader>cdb",
+  "<cmd>lua require('dap').toggle_breakpoint()<CR>",
+  opts,
+  "DAP",
+  "dap_toggle_brkpt",
+  "Toggle breakpoint on current line"
+)
+utils.map(
+  "n",
+  "<leader>cdc",
+  "<cmd>lua require('dap').toggle_breakpoint()<CR>",
+  opts,
+  "DAP",
+  "dap_continue",
+  "Start (or continue) a debug session"
+)
+utils.map(
+  "n",
+  "<leader>cdd",
+  "<cmd>lua require('dap').disconnect()",
+  "DAP",
+  "dap_disconnect",
+  "End debugging session")
+utils.map(
+  "n",
   "<leader>cde",
   "<cmd>lua require('dapui').eval()<CR>",
   opts,

--- a/lua/doom/modules/config/doom-whichkey.lua
+++ b/lua/doom/modules/config/doom-whichkey.lua
@@ -97,6 +97,9 @@ return function()
       },
       ["d"] = {
         name = "+debug",
+        ["b"] = { "Toggle breakpoint on current line"},
+        ["c"] = { "Start (or continue) a debug session" },
+        ["t"] = { "Terminate debug session"},
         ["e"] = { "Evaluate word under cursor" },
         ["s"] = { "Evaluate selection" },
       },


### PR DESCRIPTION
I found that the keybindings for the DAP module were just nonexistent.

I've added a couple of keybindings that set breakpoints, start a debugging session, and terminate the debugging session.

I'm not a big fan of the current keybinding for opening the debug session being set to <leader>od.  I was thinking of adding a keybinding for F8, since that is the first function key that is unused.