### PR TITLE
Fixed missing 'opts' param in keybinding

### DIFF
--- a/lua/doom/extras/keybindings/init.lua
+++ b/lua/doom/extras/keybindings/init.lua
@@ -1063,7 +1063,7 @@ utils.map(
 utils.map(
   "n",
   "<leader>cdc",
-  "<cmd>lua require('dap').toggle_breakpoint()<CR>",
+  "<cmd>lua require('dap').continue()<CR>",
   opts,
   "DAP",
   "dap_continue",
@@ -1073,6 +1073,7 @@ utils.map(
   "n",
   "<leader>cdd",
   "<cmd>lua require('dap').disconnect()",
+  opts,
   "DAP",
   "dap_disconnect",
   "End debugging session"


### PR DESCRIPTION
:sweat_smile:  In the previous PR I submitted, one of the calls is missing the "opts" argument, and also the keybinding for continue had the wrong command.  This commit fixes it..