### PR TITLE
Remove gcc override for treesitter and warn clang users they may have compatibility issues.

### DIFF
--- a/lua/doom/modules/config/doom-neorg.lua
+++ b/lua/doom/modules/config/doom-neorg.lua
@@ -30,22 +30,17 @@ return function()
     },
   })
 
-  --  If MacOS, check if user is using clang and notify that it has poor compatibility with treesitter
-  --  WARN: We probably won't need this forever.
+  --  Check if user is using clang and notify that it has poor compatibility with treesitter
+  --  WARN: 19/11/2021 | issues: #244, #246 clang compatibility could improve in future
   vim.defer_fn(function()
     local log = require('doom.extras.logging')
+    local utils = require('doom.utils')
     -- Matches logic from nvim-treesitter
-    local compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
-    local select_executable = function(executables)
-      return vim.tbl_filter(function(c)
-        return c ~= vim.NIL and vim.fn.executable(c) == 1
-      end, executables)[1]
-    end
-    local cc = select_executable(compilers)
-    local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
+    local compiler = utils.find_executable_in_path({ vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" })
+    local version = vim.fn.systemlist(compiler .. (compiler == "cl" and "" or " --version"))[1]
 
     if (version:match('clang')) then
-      log.warn('doom-neorg:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc instead, see issue #246 for details.')
+      log.warn('doom-neorg:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc instead, see issue #246 for details.  (https://github.com/NTBBloodbath/doom-nvim/issues/246)')
     end
   end, 1000)
 end

--- a/lua/doom/modules/config/doom-neorg.lua
+++ b/lua/doom/modules/config/doom-neorg.lua
@@ -29,4 +29,23 @@ return function()
       },
     },
   })
+
+  --  If MacOS, check if user is using clang and notify that it has poor compatibility with treesitter
+  --  WARN: We probably won't need this forever.
+  vim.defer_fn(function()
+    local log = require('doom.extras.logging')
+    -- Matches logic from nvim-treesitter
+    local compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
+    function select_executable(executables)
+      return vim.tbl_filter(function(c)
+        return c ~= vim.NIL and vim.fn.executable(c) == 1
+      end, executables)[1]
+    end
+    local cc = select_executable(compilers)
+    local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
+
+    if (version:match('Apple clang')) then
+      log.warn('doom-neorg:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc on MacOS, see issue #246 for details.')
+    end
+  end, 1000)
 end

--- a/lua/doom/modules/config/doom-neorg.lua
+++ b/lua/doom/modules/config/doom-neorg.lua
@@ -44,8 +44,8 @@ return function()
     local cc = select_executable(compilers)
     local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
 
-    if (version:match('Apple clang')) then
-      log.warn('doom-neorg:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc on MacOS, see issue #246 for details.')
+    if (version:match('clang')) then
+      log.warn('doom-neorg:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc instead, see issue #246 for details.')
     end
   end, 1000)
 end

--- a/lua/doom/modules/config/doom-neorg.lua
+++ b/lua/doom/modules/config/doom-neorg.lua
@@ -36,7 +36,7 @@ return function()
     local log = require('doom.extras.logging')
     -- Matches logic from nvim-treesitter
     local compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
-    function select_executable(executables)
+    local select_executable = function(executables)
       return vim.tbl_filter(function(c)
         return c ~= vim.NIL and vim.fn.executable(c) == 1
       end, executables)[1]

--- a/lua/doom/modules/config/doom-neorg.lua
+++ b/lua/doom/modules/config/doom-neorg.lua
@@ -31,7 +31,7 @@ return function()
   })
 
   --  Check if user is using clang and notify that it has poor compatibility with treesitter
-  --  WARN: 19/11/2021 | issues: #244, #246 clang compatibility could improve in future
+  --  WARN: 19/11/2021 | issues: #222, #246 clang compatibility could improve in future
   vim.defer_fn(function()
     local log = require('doom.extras.logging')
     local utils = require('doom.utils')

--- a/lua/doom/modules/config/doom-treesitter.lua
+++ b/lua/doom/modules/config/doom-treesitter.lua
@@ -89,8 +89,8 @@ return function()
     local cc = select_executable(compilers)
     local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
 
-    if (version:match('Apple clang')) then
-      log.warn('doom-treesitter:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc on MacOS, see issue #246 for details.')
+    if (version:match('clang')) then
+      log.warn('doom-treesitter:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc, see issue #246 for details.')
     end
   end, 1000)
 end

--- a/lua/doom/modules/config/doom-treesitter.lua
+++ b/lua/doom/modules/config/doom-treesitter.lua
@@ -76,7 +76,7 @@ return function()
   })
 
   --  Check if user is using clang and notify that it has poor compatibility with treesitter
-  --  WARN: 19/11/2021 | issues: #244, #246 clang compatibility could improve in future
+  --  WARN: 19/11/2021 | issues: #222, #246 clang compatibility could improve in future
   vim.defer_fn(function()
     local log = require('doom.extras.logging')
     local utils = require('doom.utils')

--- a/lua/doom/modules/config/doom-treesitter.lua
+++ b/lua/doom/modules/config/doom-treesitter.lua
@@ -75,22 +75,17 @@ return function()
     },
   })
 
-  --  If MacOS, check if user is using clang and notify that it has poor compatibility with treesitter
-  --  WARN: We probably won't need this forever.
+  --  Check if user is using clang and notify that it has poor compatibility with treesitter
+  --  WARN: 19/11/2021 | issues: #244, #246 clang compatibility could improve in future
   vim.defer_fn(function()
     local log = require('doom.extras.logging')
+    local utils = require('doom.utils')
     -- Matches logic from nvim-treesitter
-    local compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
-    local select_executable = function(executables)
-      return vim.tbl_filter(function(c)
-        return c ~= vim.NIL and vim.fn.executable(c) == 1
-      end, executables)[1]
-    end
-    local cc = select_executable(compilers)
-    local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
+    local compiler = utils.find_executable_in_path({ vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" })
+    local version = vim.fn.systemlist(compiler .. (compiler == "cl" and "" or " --version"))[1]
 
     if (version:match('clang')) then
-      log.warn('doom-treesitter:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc, see issue #246 for details.')
+      log.warn('doom-treesitter:  clang has poor compatibility compiling treesitter parsers.  We recommend using gcc, see issue #246 for details.  (https://github.com/NTBBloodbath/doom-nvim/issues/246)')
     end
   end, 1000)
 end

--- a/lua/doom/modules/config/doom-treesitter.lua
+++ b/lua/doom/modules/config/doom-treesitter.lua
@@ -81,7 +81,7 @@ return function()
     local log = require('doom.extras.logging')
     -- Matches logic from nvim-treesitter
     local compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
-    function select_executable(executables)
+    local select_executable = function(executables)
       return vim.tbl_filter(function(c)
         return c ~= vim.NIL and vim.fn.executable(c) == 1
       end, executables)[1]

--- a/lua/doom/utils/init.lua
+++ b/lua/doom/utils/init.lua
@@ -131,4 +131,13 @@ utils.check_plugin = function(plugin_name, path)
   ) == 1
 end
 
+--- Searches for a number of executables in the user's path
+--- @param executables table<number, string> Table of executables to search for
+--- @return string|nil First valid executable in table
+utils.find_executable_in_path = function (executables)
+  return vim.tbl_filter(function(c)
+    return c ~= vim.NIL and vim.fn.executable(c) == 1
+  end, executables)[1]
+end
+
 return utils


### PR DESCRIPTION
Clang is unable to compile some treesitter parsers.  This PR provides a warning #222 and directs users to #246 where they can solve their problem.  

It uses the same logic as nvim-treesitter to determine which compiler to use so it shouldn't have any false positives (unless compatibility with clang improves).