### PR TITLE
Fixed :DoomReport not collecting logs

### DIFF
--- a/lua/doom/core/functions/init.lua
+++ b/lua/doom/core/functions/init.lua
@@ -177,8 +177,6 @@ end
 -- occurs, useful for debugging issues.
 functions.create_report = function()
   local date = os.date("%Y-%m-%d %H:%M:%S")
-  local log_date_format = os.date("%a %d %b %Y")
-
   local created_report, err = xpcall(function()
     -- Get and save only the warning and error logs from today
     local today_logs = {}

--- a/lua/doom/core/functions/init.lua
+++ b/lua/doom/core/functions/init.lua
@@ -184,11 +184,13 @@ functions.create_report = function()
     local today_logs = {}
     local doom_logs = vim.split(fs.read_file(system.doom_logs), "\n")
     for _, doom_log in ipairs(doom_logs) do
-      if
-        string.find(doom_log, "ERROR " .. log_date_format)
-        or string.find(doom_log, "WARN  " .. log_date_format)
-      then
-        table.insert(today_logs, doom_log)
+      local preinfo = doom_log:match('%[(.+)%]')
+      if preinfo ~= nil then
+        local is_current_day = preinfo:find(os.date('%a %d %b')) ~= nil and preinfo:find(os.date('%Y')) ~= nil
+        local error_or_warn = preinfo:find('ERROR ') or preinfo:find('WARN ')
+        if error_or_warn and is_current_day then
+          table.insert(today_logs, doom_log)
+        end
       end
     end
 


### PR DESCRIPTION
This PR solves #186 (no error/warn logs in :DoomReport) by loosening the ways that dates can be formatted.  Tested and working on macos with Australian time localisation.