### PR TITLE
Fixed errors when auto reload fails for doom-*.lua files.

### DIFF
--- a/lua/doom/modules/built-in/reloader/init.lua
+++ b/lua/doom/modules/built-in/reloader/init.lua
@@ -41,7 +41,7 @@ local function path_to_lua_module(module_path)
     string.format("%s%s(.*)%%.lua", utils.escape_str(lua_path), system.sep)
   )
 
-  if module_path == nil then
+  if not module_path then
     return nil
   end
 


### PR DESCRIPTION
When editing a `doom-*.lua` file outside of your neovim config, or if editing a `doom-*.lua` file in a symlinked config (I'll use cheovim eventually) we get a nil concatenation error.  This occurs on every save and is pretty disruptive.

This PR fixes this by instead warning the user once per session.