### PR TITLE
fix telescope ignoring too many files due to regex

### DIFF
--- a/lua/doom/modules/config/doom-telescope.lua
+++ b/lua/doom/modules/config/doom-telescope.lua
@@ -31,7 +31,7 @@ return function()
         },
       },
       file_sorter = require("telescope.sorters").get_fuzzy_file,
-      file_ignore_patterns = { ".git", "node_modules", "__pycache__" },
+      file_ignore_patterns = { "^%.git$", "^node_modules$", "^__pycache__$" },
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
       winblend = 0,
       scroll_strategy = "cycle",


### PR DESCRIPTION
i realized by coincidence that telescope, as configured by doom-nvim, would ignore too many files.

For instance, create a folder with a file named `agit.txt` or `node_modulesaa` and run `spc f f` in doom-neovim: telescope won't list these files.
The reason is that telescope wants regexes for the ignore patterns:

>  A table of lua regex that define the files that should be ignored.
>  Example: { "^scratch/" } -- ignore all files in scratch directory
>  Example: { "%.npz" } -- ignore all npz files
>  See: https://www.lua.org/manual/5.1/manual.html#5.4.1 for more
>  information about lua regex

This PR changes the format of the telescope ignore pattern as configured by doom-nvim to more restrictive regular expressions as opposed to strings that blacklist many valid files.