### PR TITLE
oops, telescope ignoring pattern: these are folders not files

### DIFF
--- a/lua/doom/modules/config/doom-telescope.lua
+++ b/lua/doom/modules/config/doom-telescope.lua
@@ -31,7 +31,7 @@ return function()
         },
       },
       file_sorter = require("telescope.sorters").get_fuzzy_file,
-      file_ignore_patterns = { "^%.git$", "^node_modules$", "^__pycache__$" },
+      file_ignore_patterns = { "^%.git/", "^node_modules/", "^__pycache__/" },
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
       winblend = 0,
       scroll_strategy = "cycle",


### PR DESCRIPTION
i'm sorry, i was a little sloppy in my PR earlier. I realized since then that .git, .node_modules and __pycache__ are FOLDERS, not files. therefore the regex to hide them must end in /, not in $ -- same as in the telescope documentation:

> A table of lua regex that define the files that should be ignored.
> Example: { "^scratch/" } -- ignore all files in scratch directory
> Example: { "%.npz" } -- ignore all npz files
> See: https://www.lua.org/manual/5.1/manual.html#5.4.1 for more
> information about lua regex