### PR TITLE
telescope ignore pattern: must escape the '.'

### DIFF
--- a/lua/doom/modules/config/doom-telescope.lua
+++ b/lua/doom/modules/config/doom-telescope.lua
@@ -31,7 +31,7 @@ return function()
         },
       },
       file_sorter = require("telescope.sorters").get_fuzzy_file,
-      file_ignore_patterns = { "^.git/", "^node_modules/", "^__pycache__/" },
+      file_ignore_patterns = { "^%.git/", "^node_modules/", "^__pycache__/" },
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
       winblend = 0,
       scroll_strategy = "cycle",


### PR DESCRIPTION
Hi, after my PRs on main regarding this telescope ignore pattern yesterday, I realized the fix was already on the develop branch.. Except that there the `.` in .git wasn't escaped, so we would also ignore for instance a folder named `agit`. This is now the same as what's right now in the `main` branch.