### PR TITLE
add shortcuts for telescope search history

### DIFF
--- a/lua/doom/modules/config/doom-telescope.lua
+++ b/lua/doom/modules/config/doom-telescope.lua
@@ -62,6 +62,8 @@ return function()
           ["<C-q>"] = actions.smart_send_to_qflist + actions.open_qflist,
           ["<Leader>f"] = actions.close, -- works like a toggle, sometimes can be buggy
           ["<CR>"] = actions.select_default + actions.center,
+          ["<C-n>"] = actions.cycle_history_next,
+          ["<C-p>"] = actions.cycle_history_prev,
         },
         n = {
           ["<C-j>"] = actions.move_selection_next,


### PR DESCRIPTION
bind by default shortcuts in telescope for previous & next history entries. See `:help telescope.defaults.history` and https://github.com/nvim-telescope/telescope.nvim/issues/1208 and https://github.com/nvim-telescope/telescope.nvim/pull/521

I don't see any downside to this, only upsides, that's why I'm suggesting it.

And if you think this belongs in doom-nvim by default, I also wonder about potentially adding:
```
      path_display = {'truncate'},
```
to telescope settings, in a separate PR, if you would be interested. It's documented at `telescope.defaults.path_display`. By default, telescope cuts the end of a filename. And the end is the most interesting part... It contains the actual filename you'll open. With truncate, it will cut the start, which is a reasonable default. There are more advanced options (like cut individual folder names in the path), but truncate seems to be a reasonable default, better than cutting at the end. Let me know if you would be interested in such a separate PR too.