### PR TITLE
fix bug #259 "nvim-lspconfig broke doom stable"

### DIFF
--- a/lua/doom/modules/init.lua
+++ b/lua/doom/modules/init.lua
@@ -310,6 +310,7 @@ packer.startup(function(use)
     config = require("doom.modules.config.doom-lspconfig"),
     disable = disabled_lsp,
     event = "ColorScheme",
+    commit = '2e6c94069e92cb4a43416b3ac0267e941b3fd47e',
   })
 
   -- Completion plugin


### PR DESCRIPTION
This pull request "works around" bug #259. Good enough until the next doom-nvim release.