### PR TITLE
Improve configuration to allow running code

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -306,8 +306,9 @@ a previous release (for main branch) or a previous commit (for development branc
 ## Configuration
 
 You can configure Doom Nvim by tweaking the `doom_config.lua`,
-`doom_modules.lua` and the `doom_userplugins.lua` files located in your
-Doom Nvim root directory (`$HOME/.config/doom-nvim/` by default).
+`doom_modules.lua`, `doom_userplugins.lua` and the `doom_startup.lua` files
+located in your Doom Nvim root directory (`$HOME/.config/doom-nvim/` by
+default).
 
 ### doom_modules.lua
 
@@ -452,6 +453,30 @@ and install or uninstall the plugins declared on here.
 
 > **NOTE**: all the valid options for declaring plugins can be found in
 > [specifying plugins](https://github.com/wbthomason/packer.nvim#specifying-plugins).
+
+### doom_startup.lua
+
+This file allows you to configure and override settings not encompassed by
+`doom_config.lua`. Really, its just run with the `luafile` command, after Doom
+initialization, so its safe to `require` any modules and override their config.
+
+The only requirement is that a table is returned with a `source` field
+containing its real path. Therefore, the file would generally look like this:
+
+```lua
+local M = {}
+
+M.source = debug.getinfo(1, "S").source:sub(2)
+
+-- Your startup logic...
+
+return M
+```
+
+> **NOTE**: try to use `doom_config.lua` before falling back on this, as any
+> settings accounted for there are more likely to be well integrated into Doom.
+> Also, consider contributing an integration to suit your needs, we'd really
+> appreciate that!
 
 ### Modules
 

--- a/init.lua
+++ b/init.lua
@@ -4,6 +4,19 @@
 --             License: GPLv2                  --
 ---[[---------------------------------------]]---
 
+-- Check if running Neovim or Vim and fails fast if:
+-- 1. Running Vim instead of Neovim
+-- 2. Running Neovim 0.4 or below
+local log = require("doom.extras.logging")
+if vim.fn.has("nvim") == 1 then
+  if vim.fn.has("nvim-0.5") ~= 1 then
+    log.fatal("Doom Nvim requires Neovim 0.5.0, please update it")
+  end
+else
+  log.fatal("Doom Nvim does not have support for Vim, please use it with Neovim instead")
+end
+
+
 ---- Doom Utilities -----------------------------
 -------------------------------------------------
 -- Store startup time in seconds
@@ -52,5 +65,10 @@ vim.defer_fn(function()
     vim.cmd([[
       PackerLoad which-key.nvim
     ]])
+  end
+
+  local startup_file = require("doom.core.config.startup").source
+  if require("doom.utils.fs").file_exists(startup_file) then
+    vim.cmd("luafile " .. startup_file)
   end
 end, 0)

--- a/lua/doom/core/config/init.lua
+++ b/lua/doom/core/config/init.lua
@@ -9,19 +9,6 @@ local config = {}
 local log = require("doom.extras.logging")
 local system = require("doom.core.system")
 
-log.debug("Loading Doom config module ...")
-
--- Check if running Neovim or Vim and fails if:
--- 1. Running Vim instead of Neovim
--- 2. Running Neovim 0.4 or below
-if vim.fn.has("nvim") == 1 then
-  if vim.fn.has("nvim-0.5") ~= 1 then
-    log.fatal("Doom Nvim requires Neovim 0.5.0, please update it")
-  end
-else
-  log.fatal("Doom Nvim does not have support for Vim, please use it with Neovim instead")
-end
-
 -- Set termguicolors on load
 if vim.fn.has("vim_starting") then
   vim.opt.termguicolors = true

--- a/lua/doom/core/config/startup.lua
+++ b/lua/doom/core/config/startup.lua
@@ -1,0 +1,30 @@
+local startup = {}
+
+local system = require("doom.core.system")
+local log = require("doom.extras.logging")
+
+startup.source = nil
+
+log.debug("Loading Doom startup module ...")
+-- Path cases:
+--   1. /home/user/.config/doom-nvim/doom_startup.lua
+--   2. stdpath('config')/doom_startup.lua
+--   3. <runtimepath>/doom_startup.lua
+local ok, ret = xpcall(dofile, debug.traceback, system.doom_configs_root .. "/doom_startup.lua")
+if ok then
+  startup.source = ret.source
+else
+  ok, ret = xpcall(dofile, debug.traceback, system.doom_root .. "/doom_startup.lua")
+  if ok then
+    startup.source = ret.source
+  else
+    ok, ret = xpcall(require, debug.traceback, "doom_startup")
+    if ok then
+      startup.source = ret.source
+    else
+      log.error("Error while loading doom_startup.lua. Traceback:\n" .. ret)
+    end
+  end
+end
+
+return startup

--- a/lua/doom/core/functions/init.lua
+++ b/lua/doom/core/functions/init.lua
@@ -469,6 +469,7 @@ functions.edit_config = function()
     "1. doom_config.lua",
     "2. doom_modules.lua",
     "3. doom_userplugins.lua",
+    "4. doom_startup.lua"
   }))
   local direction = config.doom.vertical_split and "vert " or ""
   local open_command = config.doom.new_file_split and "split" or "edit"
@@ -480,6 +481,10 @@ functions.edit_config = function()
   elseif selected_config == 3 then
     vim.cmd(
       ("%s%s %s"):format(direction, open_command, require("doom.core.config.userplugins").source)
+    )
+  elseif selected_config == 4 then
+    vim.cmd(
+      ("%s%s %s"):format(direction, open_command, require("doom.core.config.startup").source)
     )
   elseif selected_config ~= 0 then
     log.error("Invalid option selected.")


### PR DESCRIPTION
## tl;dr
This allows running arbitrary user code _after_ Doom initialization, when modules are loaded and ready to `require`.
There's also discussion a perhaps better method, albeit one that would cause breaking changes.

## Full story
First of all, I'd like to say that this project is very interesting. I just changed from LunarVim, and I'm quite happy, but there were some obstacles I faced, namely, the apparent lack of support for just "running code" after Doom startup. Add to it that this is a very young project without all the options accounted for, and you run into issues with configuring plugins beyond a limit. That's where this PR comes in.

It implements a new configuration file, `doom_startup.lua`, that is run after everything else (see [`init.lua`](https://github.com/LuigiPiucco/doom-nvim/blob/develop/init.lua#L58-L63)), and really it just runs. This allows state modifications, such as: 

- Adding `which-key` bindings yourself;
- Overriding lsp config per language (this is needed in NixOS, for instance, where I actually want the carefully chosen server in `$PATH` to be used in place of whatever `lspinstall` downloads);
- Loading extensions which need to be registered, such as `Telescope` plugins;
- Really many more things.

Right now, the only limitation imposed on the startup file is that it returns to the caller a table with `source` set to its path, since all other config files also rely on that. This introduces a bit of boilerplate:

```lua
local M = {}

M.source = debug.getinfo(1, "S").source:sub(2)

-- Your startup logic...

return M
```

## Alternatives
In Doom Emacs, this functionality is done through `$DOOMDIR/config.el` and, in fact, there's no real equivalent of Doom Nvim's `doom_config.lua`, because settings are just variables that can be set, and "running code" includes setting variables. Therefore, maybe it would be better in the long run to change config behavior to more closely match that. An approach I can think of is similar to LunarVim's: inject a table into the config and allow the user to change it to reflect their taste. We would need one (maybe two, depending on the granularity wanted) special keys, something like `post_startup` and (optionally) `pre_startup`, that could be set to a function to be run after/before everything is loaded.

If requested, I could work on such changes, though I'm a little low on time for this and the next week, I may be slow to finish.