### PR TITLE
Add stipulation for MacOS users with gnu sed

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -290,6 +290,7 @@ git clone --depth 1 https://github.com/NTBBloodbath/doom-nvim.git ${XDG_CONFIG_H
 
 # Change the doom-nvim internal path
 sed -i "37s/nvim/doom-nvim/" ${XDG_CONFIG_HOME:-$HOME/.config}/doom-nvim/lua/doom/core/system/init.lua
+# MacOS users will snag here. `brew install gnu-sed` will let you run the above command with `gsed` vice `sed`
 ```
 
 ```lua


### PR DESCRIPTION
MacOS ships with a non-standard (non GNU) version of `sed`. 

This command (`sed -i "37s/nvim/doom-nvim/" ~/.config/doom-nvim/lua/doom/core/system/init.lua`) will fail with `sed: 1: "/Users/username/.config/d ...": invalid command code m`

`gsed` works fine but will require an extra step.