### PR TITLE
Add Terraform support

### DIFF
--- a/doom_modules.lua
+++ b/doom_modules.lua
@@ -79,6 +79,7 @@ M.modules = {
     -- "comment",         -- Better annotations and comments
     -- "config",          -- Configuration files (JSON, YAML, TOML)
     -- "dockerfile",      -- Do you like containers, right?
+    -- "terraform",       -- Terraform and HCL support
   },
   utilities = {
     -- "lazygit",         -- LazyGit integration for Neovim, requires LazyGit

--- a/lua/doom/modules/config/doom-lsp-installer.lua
+++ b/lua/doom/modules/config/doom-lsp-installer.lua
@@ -51,6 +51,7 @@ return function()
     -- solang = { 'solang' },
     -- sorbet = { 'sorbet' },
     svelte = { "svelte" },
+    terraform = { "terraformls" },
     typescript = { "tsserver" },
     -- vala = { 'valals' },
     vim = { "vimls" },

--- a/lua/doom/modules/config/doom-treesitter.lua
+++ b/lua/doom/modules/config/doom-treesitter.lua
@@ -15,6 +15,9 @@ return function()
         table.insert(langs, "json")
         table.insert(langs, "yaml")
         table.insert(langs, "toml")
+      -- If the lang is Terraform then add parser for HCL
+      elseif lang:find("terraform") then
+        table.insert(langs, "hcl")
       else
         lang = lang:gsub("%s+%+lsp(%(%a+%))", ""):gsub("%s+%+lsp", ""):gsub("%s+%+debug", "")
         table.insert(langs, lang)


### PR DESCRIPTION
### Description

Added support for Terraform as a language to be enabled via `doom_modules.lua`. Terraform is a little weird, as it's Tree-sitter parser is simply `hcl` (the config language Terraform is written in) - hence the extra logic here.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have checked [contributing guidelines](https://github.com/NTBBloodbath/doom-nvim/blob/main/docs/contributing.md#contributing-code)
- [x] I have tested my code
