### PR TITLE
Remove outdated MacPorts statement

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -77,8 +77,6 @@ brew install neovim --HEAD
 nvim --version
 ```
 
-MacPorts currently only has Neovim v0.4.4
-
 #### On Windows
 
 ##### [Chocolatey](https://community.chocolatey.org/)


### PR DESCRIPTION
This states that MacPorts only has Neovim 0.4.4 but right now it has the latest version (0.6.1). I've removed the statement
https://ports.macports.org/port/neovim/