### PR TITLE
Fix error when logging to file

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,9 @@ if vim.fn.has("nvim-0.6.0") ~= 1 then
   return
 end
 
+-- Makes sure ~/.local/share/nvim exists, to prevent problems with logging
+vim.fn.mkdir(vim.fn.stdpath("data"), 'p')
+
 -- Add ~/.local/share to runtimepath early, such that
 -- neovim autoloads plugin/packer_compiled.lua along with vimscript,
 -- before we start using the plugins it lazy-loads.

--- a/lua/doom/utils/logging.lua
+++ b/lua/doom/utils/logging.lua
@@ -111,9 +111,13 @@ log.new = function(config, standalone)
     -- Output to log file
     if config.use_file then
       local fp = io.open(outfile, "a")
-      local str = string.format("[%-6s%s] %s: %s\n", nameupper, os.date(), lineinfo, msg)
-      fp:write(str)
-      fp:close()
+      if not fp then
+        vim.cmd(string.format([[echom "Couldn't open log file [%s]"]], outfile))
+      else
+        local str = string.format("[%-6s%s] %s: %s\n", nameupper, os.date(), lineinfo, msg)
+        fp:write(str)
+        fp:close()
+      end
     end
   end
 


### PR DESCRIPTION
When `vim.fn.stdpath('data')` does not exists, logging fails when trying to open the `doom.log` file. This both adds a check that the log file could be opened, and makes sure the data directory exists when starting neovim.