### PR TITLE
Make `is_module_enabled` depend on module section

### DIFF
--- a/lua/doom/core/functions.lua
+++ b/lua/doom/core/functions.lua
@@ -156,7 +156,7 @@ functions.toggle_background = function()
 end
 
 -- Only define if lsp enabled, it only makes sense there.
-if is_module_enabled("lsp") then
+if is_module_enabled("features", "lsp") then
   -- Toggle completion (by running cmp setup again).
   functions.toggle_completion = function()
     _doom.cmp_enable = not _doom.cmp_enable

--- a/lua/doom/modules/core/doom/init.lua
+++ b/lua/doom/modules/core/doom/init.lua
@@ -122,7 +122,7 @@ required.binds = function()
     table.insert(binds, { esc_seq, "<ESC>", mode = "i" })
   end
 
-  if is_module_enabled("explorer") then
+  if is_module_enabled("features", "explorer") then
     table.insert(binds, { "<F3>", ":Lexplore%s<CR>", name = "Toggle explorer" })
     table.insert(binds, {
       "<leader>",

--- a/lua/doom/modules/core/treesitter/init.lua
+++ b/lua/doom/modules/core/treesitter/init.lua
@@ -63,7 +63,7 @@ treesitter.configs["nvim-treesitter"] = function()
   local is_module_enabled = require("doom.utils").is_module_enabled
   require("nvim-treesitter.configs").setup(vim.tbl_deep_extend("force", doom.core.treesitter.settings.treesitter, {
     autopairs = {
-      enable = is_module_enabled("autopairs"),
+      enable = is_module_enabled("features", "autopairs"),
     },
   }))
 

--- a/lua/doom/modules/features/auto_install/init.lua
+++ b/lua/doom/modules/features/auto_install/init.lua
@@ -17,14 +17,14 @@ auto_install.packages = {
       "DIList",
       "DIUninstall",
     },
-    disabled = not is_module_enabled("dap"),
+    disabled = not is_module_enabled("features", "dap"),
     module = "dap-install",
     disable = true,
   },
   ["nvim-lsp-installer"] = {
     "williamboman/nvim-lsp-installer",
     commit = "effafae44012a6ad3091968ad358531c62925a45",
-    -- disabled = not is_module_enabled("lsp"),
+    -- disabled = not is_module_enabled("features", "lsp"),
     module = "nvim-lsp-installer",
   },
 }

--- a/lua/doom/modules/features/dashboard/init.lua
+++ b/lua/doom/modules/features/dashboard/init.lua
@@ -79,13 +79,13 @@ dashboard.configs["dashboard-nvim"] = function()
   local db = require("dashboard")
   local is_module_enabled = utils.is_module_enabled
 
-  if is_module_enabled("auto_session") then
+  if is_module_enabled("features", "auto_session") then
     vim.g.dashboard_session_directory = doom.features.auto_session.settings.dir
   end
-  if is_module_enabled("telescope") then
+  if is_module_enabled("features", "telescope") then
     vim.g.dashboard_default_executive = "telescope"
   end
-  if is_module_enabled("auto_session") then
+  if is_module_enabled("features", "auto_session") then
     doom.features.dashboard.settings.entries.a = {
       icon = "  ",
       desc = "Load Last Session              ",
@@ -146,7 +146,7 @@ dashboard.autocmds = {
       -- 2. Bytes count from the start of the buffer to the end (it should be non-existent, -1)
       -- 3. Existence of the buffer
       if vim.fn.argc() == 0 and vim.fn.line2byte("$") == -1 and vim.fn.bufexists(0) == 0 then
-        if is_module_enabled("dashboard") then
+        if is_module_enabled("features", "dashboard") then
           vim.cmd("Dashboard")
         end
       end

--- a/lua/doom/modules/features/explorer/init.lua
+++ b/lua/doom/modules/features/explorer/init.lua
@@ -114,7 +114,7 @@ explorer.configs["nvim-tree.lua"] = function()
   local tree_cb = require("nvim-tree.config").nvim_tree_callback
 
   local override_table
-  if is_module_enabled("lsp") then
+  if is_module_enabled("features", "lsp") then
     override_table = {
       diagnostics = {
         enable = true,

--- a/lua/doom/modules/features/lsp/init.lua
+++ b/lua/doom/modules/features/lsp/init.lua
@@ -92,7 +92,7 @@ lsp.packages = {
   ["nvim-cmp"] = {
     "hrsh7th/nvim-cmp",
     commit = "15c7bf7c0dfb7c75eb526c53f9574633c13dc22d",
-    after = is_module_enabled("snippets") and "LuaSnip" or nil,
+    after = is_module_enabled("features", "snippets") and "LuaSnip" or nil,
   },
   ["cmp-nvim-lua"] = {
     "hrsh7th/cmp-nvim-lua",
@@ -118,7 +118,7 @@ lsp.packages = {
     "saadparwaiz1/cmp_luasnip",
     commit = "a9de941bcbda508d0a45d28ae366bb3f08db2e36",
     after = "nvim-cmp",
-    disabled = not is_module_enabled("snippets"),
+    disabled = not is_module_enabled("features", "snippets"),
   },
   ["lsp_signature.nvim"] = {
     "ray-x/lsp_signature.nvim",
@@ -184,7 +184,7 @@ lsp.configs["nvim-lspconfig"] = function()
 end
 lsp.configs["nvim-cmp"] = function()
   local utils = require("doom.utils")
-  local snippets_enabled = utils.is_module_enabled("snippets")
+  local snippets_enabled = utils.is_module_enabled("features", "snippets")
 
   local cmp = require("cmp")
   local luasnip = snippets_enabled and require("luasnip")

--- a/lua/doom/modules/features/telescope/init.lua
+++ b/lua/doom/modules/features/telescope/init.lua
@@ -165,7 +165,7 @@ telescope.binds = function()
       },
     },
   }
-  if is_module_enabled("lsp") then
+  if is_module_enabled("features", "lsp") then
     table.insert(binds, {
       "<leader>",
       name = "+prefix",

--- a/lua/doom/modules/langs/utils.lua
+++ b/lua/doom/modules/langs/utils.lua
@@ -24,7 +24,7 @@ end
 
 module.use_lsp = function(lsp_name, options)
   local utils = require('doom.utils')
-  if not utils.is_module_enabled("lsp") then
+  if not utils.is_module_enabled("features", "lsp") then
     return
   end
   local lsp = require('lspconfig')
@@ -40,7 +40,7 @@ module.use_lsp = function(lsp_name, options)
 
   -- Combine default on_attach with provided on_attach
   local on_attach_functions = {}
-  if utils.is_module_enabled("illuminate") then
+  if utils.is_module_enabled("features", "illuminate") then
     table.insert(on_attach_functions, utils.illuminate_attach)
   end
   if (opts.config and opts.config.on_attach) then

--- a/lua/doom/utils/init.lua
+++ b/lua/doom/utils/init.lua
@@ -201,19 +201,14 @@ utils.get_diagnostic_count = function(bufnr, severity)
 end
 
 --- Check if the given plugin is disabled in doom-nvim/modules.lua
---- @param plugin string The plugin identifier, e.g. statusline
+--- @param section string The module section, e.g. features
+--- @param plugin string The module identifier, e.g. statusline
 --- @return boolean
-utils.is_module_enabled = function(plugin)
+utils.is_module_enabled = function(section, plugin)
   local modules = require("doom.core.modules").enabled_modules
 
-  -- Iterate over all modules sections (e.g. ui) and their plugins
-  for _, section in pairs(modules) do
-    if vim.tbl_contains(section, plugin) then
-      return true
-    end
-  end
-
-  return false
+  return modules[section]
+    and vim.tbl_contains(modules[section], plugin)
 end
 
 local modules_list_cache = {}


### PR DESCRIPTION
Having `is_module_enabled` only takes the module names prevents us from distinguishing two modules with the same name in different sessions.