### PR TITLE
Fix a typo in =SPC `= (Browse cwd) command.

### DIFF
--- a/lua/doom/modules/features/telescope/init.lua
+++ b/lua/doom/modules/features/telescope/init.lua
@@ -100,7 +100,7 @@ telescope.binds = function()
       {
         "`",
         function()
-          require("telescope.builtin").find_files({ cwd = vim.fn.expand("%:p:n") })
+          require("telescope.builtin").find_files({ cwd = vim.fn.expand("%:p:h") })
         end,
         name = "Browse cwd",
       },


### PR DESCRIPTION
Also, if we run `` SPC ` `` before a `Telescope find_files` command, an error will be thrown. Seems that the `telescope.builtin`  package cannot be loaded properly before `telescope` is loaded.