### PR TITLE
chore: docker fixes, including clean bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tags
 # Doom Nvim Contrib files
 tools/doom-nvim-contrib
 tools/local-share-nvim
+tools/local-state
 tools/workspace
 
 # User modules

--- a/lua/doom/core/init.lua
+++ b/lua/doom/core/init.lua
@@ -71,8 +71,10 @@ modules.try_sync()
 profiler.stop("framework|doom.core.modules")
 
 -- Execute autocommand for user to hook custom config into
-vim.api.nvim_exec_autocmds("User", {
-  pattern = "DoomStarted",
-})
+if not modules._needs_sync then
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "DoomStarted",
+  })
+end
 
 -- vim: fdm=marker

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -39,6 +39,9 @@ RUN npm i -g chokidar-cli
 # For startup time profiling
 RUN pacman -Sy hyperfine --noconfirm
 
+# OCaml
+RUN pacman -Sy opam diffutils patch ocaml --noconfirm
+
 # Create the doom user and group
 RUN groupadd doom
 RUN useradd -m -g doom doom

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -25,7 +25,7 @@ RUN pacman -Sy neovim --noconfirm
 RUN pacman -Sy ripgrep nodejs-lts-fermium npm git bash gcc jq --noconfirm
 
 # Lua
-RUN pacman -Sy luacheck stylua --noconfirm
+RUN pacman -Sy luacheck stylua lua-language-server --noconfirm
 
 # Required for nvim-lsp-installer
 RUN pacman -Sy wget unzip make --noconfirm

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,7 +16,7 @@ ENV \
 	PATH="/home/doom/.local/bin:${PATH}"
 
 # Update repositories
-RUN	pacman -Syy
+RUN	pacman -Syu --noconfirm
 
 # Install neovim
 RUN pacman -Sy neovim --noconfirm

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -36,6 +36,9 @@ RUN npm i -g chokidar-cli
 # Required for OCaml language
 # RUN pacman -Sy opam diffutils patch ocaml --noconfirm
 
+# For startup time profiling
+RUN pacman -Sy hyperfine --noconfirm
+
 # Create the doom user and group
 RUN groupadd doom
 RUN useradd -m -g doom doom

--- a/tools/docker_bootstrap.sh
+++ b/tools/docker_bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "Executing initial bootstrap/sync"
+rm -f local-share-nvim/plugin/packer_compiled.lua
+rm -f doom-nvim-contrib/plugin/packer_compiled.lua
+rm -rf local-share-nvim/ local-state-nvim/
+./start_docker.sh -- --rm --entrypoint='["/usr/bin/nvim","--headless","--cmd","autocmd User PackerComplete quitall","--cmd","autocmd User DoomStarted PackerSync"]'
+./start_docker.sh -- --rm --entrypoint='["/usr/bin/nvim","--headless","--cmd","autocmd User PackerComplete quitall","--cmd","autocmd User DoomStarted PackerSync"]'
+echo "Testing config"
+exec ./start_docker.sh -- --rm --entrypoint='["/usr/bin/nvim","--headless","+qa"]'

--- a/tools/docker_clean_bootstrap.sh
+++ b/tools/docker_clean_bootstrap.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+rm local-share-nvim/ local-state-nvim/ -rf
+rm -f doom-nvim-contrib/plugin/packer_compiled.lua
+echo
+echo "Bootstrapping packages"
+echo
+exec ./start_docker.sh -- --entrypoint='["/usr/bin/nvim","--headless","--cmd","autocmd User PackerComplete quitall"]'

--- a/tools/start_docker.sh
+++ b/tools/start_docker.sh
@@ -96,7 +96,7 @@ echo "2. Setting up docker environment"
 # Ensure docker image exists
 if [[ ! "$("${DOCKER}" images -q doom-nvim-contrib)" ]]; then
   echo " - Docker image does not exist.  Building docker image..."
-  "${DOCKER}" build -t doom-nvim-contrib .
+  "${DOCKER}" build -t doom-nvim-contrib . || exit
 fi
 
 if [ "$("${DOCKER}" ps -aq -f status=exited -f name=doom-nvim-contrib-container)" ]; then

--- a/tools/start_docker.sh
+++ b/tools/start_docker.sh
@@ -107,7 +107,7 @@ fi
 
 # Create docker container if haven't already
 echo " - Success! Running docker container doom-nvim-contrib-container..."
-mkdir -p "${SCRIPT_DIR}/local-share-nvim" "${SCRIPT_DIR}/workspace"
+mkdir -p "${SCRIPT_DIR}/local-share-nvim" "${SCRIPT_DIR}/local-state" "${SCRIPT_DIR}/workspace"
 echo ""
 ${DOCKER} run \
   ${DOCKER_RUN_FLAGS} \
@@ -115,6 +115,7 @@ ${DOCKER} run \
   -e UID="1000" \
   -e GID="1000" \
   -v "$SCRIPT_DIR"/doom-nvim-contrib:/home/doom/.config/nvim:Z \
+  -v "$SCRIPT_DIR"/local-state:/home/doom/.local/state:Z \
   -v "$SCRIPT_DIR"/local-share-nvim:/home/doom/.local/share/nvim:Z \
   -v "$SCRIPT_DIR"/workspace:/home/doom/workspace:Z \
   --name doom-nvim-contrib-container \

--- a/tools/start_docker.sh
+++ b/tools/start_docker.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
-
-if ! docker info > /dev/null 2>&1; then
+DOCKER=$(command -v podman docker | head -n 1)
+if ! "${DOCKER}" info > /dev/null 2>&1; then
   echo "This script uses docker, and it isn't running - please start docker and try again!"
   exit 1
+fi
+
+if [ $(basename "${DOCKER}") = "podman" ]; then
+	DOCKER_RUN_FLAGS="--userns=keep-id"
+else
+    DOCKER_RUN_FLAGS=
 fi
 
 ############################################################
@@ -40,6 +46,7 @@ while getopts "b:h" option; do
       exit;;
   esac
 done
+shift $((OPTIND-1))
 
 cd "$SCRIPT_DIR" || exit
 
@@ -87,30 +94,30 @@ echo ""
 
 echo "2. Setting up docker environment"
 # Ensure docker image exists
-if [[ ! "$(docker images -q doom-nvim-contrib)" ]]; then
+if [[ ! "$("${DOCKER}" images -q doom-nvim-contrib)" ]]; then
   echo " - Docker image does not exist.  Building docker image..."
-  docker build -t doom-nvim-contrib .
+  "${DOCKER}" build -t doom-nvim-contrib .
 fi
 
-if [ "$(docker ps -aq -f status=exited -f name=doom-nvim-contrib-container)" ]; then
+if [ "$("${DOCKER}" ps -aq -f status=exited -f name=doom-nvim-contrib-container)" ]; then
   echo " - Cleaning up old container..."
   # cleanup
-  docker rm doom-nvim-contrib-container >> /dev/null
+  "${DOCKER}" rm doom-nvim-contrib-container >> /dev/null
 fi
 
 # Create docker container if haven't already
 echo " - Success! Running docker container doom-nvim-contrib-container..."
 mkdir -p "${SCRIPT_DIR}/local-share-nvim" "${SCRIPT_DIR}/workspace"
 echo ""
-docker run \
+${DOCKER} run \
+  ${DOCKER_RUN_FLAGS} \
   -it \
   -e UID="1000" \
   -e GID="1000" \
-  -v "$SCRIPT_DIR"/doom-nvim-contrib:/home/doom/.config/nvim \
-  -v "$SCRIPT_DIR"/local-share-nvim:/home/doom/.local/share/nvim \
-  -v "$SCRIPT_DIR"/workspace:/home/doom/workspace \
+  -v "$SCRIPT_DIR"/doom-nvim-contrib:/home/doom/.config/nvim:Z \
+  -v "$SCRIPT_DIR"/local-share-nvim:/home/doom/.local/share/nvim:Z \
+  -v "$SCRIPT_DIR"/workspace:/home/doom/workspace:Z \
   --name doom-nvim-contrib-container \
   --user doom \
-  doom-nvim-contrib
-
-
+  "$@" \
+  doom-nvim-contrib \


### PR DESCRIPTION
The docker-podman wrapper created volume mounts are owned by the root
user inside the container, and the doom user wouldn't have write access.
Need to specify --user-ns=keep-id flag to map $UID from the host to $UID
from the container without using subuids: that way user inside container
can modify.

SELinux is on by default on Fedora36, thus volume mounts need to specify
the 'Z' flag to relabel the directory being mounted.

I've only tested this on Fedora, applies on top of https://github.com/NTBBloodbath/doom-nvim/pull/371.
Opened as a separate PR since it might need testing on other OSes, to check that the docker command still works there, in particular on non-SELinux systems.