### PR TITLE
feat(ocaml): add language

### DIFF
--- a/lua/doom/modules/langs/ocaml/init.lua
+++ b/lua/doom/modules/langs/ocaml/init.lua
@@ -1,0 +1,26 @@
+local ocaml = {}
+
+ocaml.settings = {
+  language_server_name = "ocamllsp",
+}
+
+ocaml.autocmds = {
+  {
+    "Filetype",
+    "ocaml,ocaml_interface,ocamllex",
+    function()
+      local langs_utils = require("doom.modules.langs.utils")
+      langs_utils.use_lsp(doom.langs.ocaml.settings.language_server_name)
+
+      vim.schedule(function()
+        require("nvim-treesitter.install").ensure_installed("ocaml","ocaml_interface")
+        if vim.fn.executable("tree-sitter-cli") == 1 then
+            require("nvim-treesitter.install").ensure_installed("ocamllex")
+        end
+      end)
+    end,
+    once = true,
+  },
+}
+
+return ocaml

--- a/modules.lua
+++ b/modules.lua
@@ -72,6 +72,7 @@ return {
     -- Compiled
     -- "rust",
     -- "cc",
+    -- "ocaml",
 
     -- JIT
     -- "c_sharp",

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -33,6 +33,9 @@ RUN pacman -Sy wget unzip make --noconfirm
 # Required for watching Doom-nvim-contrib for changes
 RUN npm i -g chokidar-cli
 
+# Required for OCaml language
+# RUN pacman -Sy opam diffutils patch ocaml --noconfirm
+
 # Create the doom user and group
 RUN groupadd doom
 RUN useradd -m -g doom doom
@@ -42,6 +45,9 @@ RUN chown -R ${UNAME}:${GNAME} /usr/local/lib/node_modules/
 
 USER doom
 WORKDIR /home/doom
+
+# Required for OCaml language
+# RUN opam init --disable-sandboxing && opam install ocaml-lsp-server -y
 
 COPY _docker_entry.sh /usr/local/bin/
 


### PR DESCRIPTION
Uses https://ocaml.org/p/ocaml-lsp-server/ as language server that can
be installed via `opam`.

Can be tested if I add this to the Dockerfile:
```diff
diff --git a/tools/Dockerfile b/tools/Dockerfile
index 5f2d7ce..e0bc98e 100644
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -36,6 +36,9 @@ RUN npm i -g chokidar-cli
 # For startup time profiling
 RUN pacman -Sy hyperfine --noconfirm
 
+# OCaml
+RUN pacman -Sy opam diffutils patch ocaml --noconfirm
+
 # Create the doom user and group
 RUN groupadd doom
 RUN useradd -m -g doom doom
@@ -46,6 +49,8 @@ RUN chown -R ${UNAME}:${GNAME} /usr/local/lib/node_modules/
 USER doom
 WORKDIR /home/doom
 
+RUN opam init --disable-sandboxing && opam install ocaml-lsp-server -y
+
 COPY _docker_entry.sh /usr/local/bin/
 
 # Doom-nvim-contrib
```

And then run `eval $(opam env); nvim` inside.

I've been using this for quite a while on 3.3.0, but the port to 4.0.1 is still fresh and needs more testing, hence opening as a draft PR.
Please feel free to point out if this is not the way to add a new language.