### PR TITLE
Fix netrw and explorer features

### DIFF
--- a/lua/doom/core/init.lua
+++ b/lua/doom/core/init.lua
@@ -25,11 +25,6 @@ g.loaded_matchparen = 1
 g.loaded_logiPat = 1
 g.loaded_rrhelper = 1
 
-g.loaded_netrw = 1
-g.loaded_netrwPlugin = 1
-g.loaded_netrwSettings = 1
-g.loaded_netrwFileHandlers = 1
-
 -- Sets the `doom` global object
 require("doom.core.doom_global")
 
@@ -38,6 +33,12 @@ local utils = require("doom.utils")
 -- Boostraps the doom-nvim framework, runs the user's `config.lua` file.
 local config = utils.safe_require("doom.core.config")
 config.load()
+if not utils.is_module_enabled("features", "netrw") then
+    g.loaded_netrw = 1
+    g.loaded_netrwPlugin = 1
+    g.loaded_netrwSettings = 1
+    g.loaded_netrwFileHandlers = 1
+end
 
 -- Load the colourscheme
 utils.safe_require("doom.core.ui")

--- a/lua/doom/modules/features/explorer/init.lua
+++ b/lua/doom/modules/features/explorer/init.lua
@@ -17,7 +17,6 @@ explorer.settings = {
   view = {
     width = 35,
     side = "left",
-    auto_resize = true,
     mappings = {
       custom_only = false,
     },
@@ -72,6 +71,7 @@ explorer.settings = {
   },
   actions = {
     open_file = {
+      resize_window = true, -- previously view.auto_resize
       window_picker = {
         exclude = {
           filetype = {

--- a/lua/doom/modules/features/explorer/init.lua
+++ b/lua/doom/modules/features/explorer/init.lua
@@ -95,6 +95,7 @@ explorer.packages = {
   ["nvim-tree.lua"] = {
     "kyazdani42/nvim-tree.lua",
     commit = "7fcb48c852b9d58709169a4dc1ec634fa9ea56f9",
+    module = 'nvim-tree.api',
     cmd = {
       "NvimTreeClipboard",
       "NvimTreeClose",
@@ -182,6 +183,15 @@ explorer.binds = {
       },
     },
   },
+}
+
+explorer.autocmds = {
+    {"BufEnter", "*", function()
+       local name = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
+        if vim.fn.isdirectory(name) == 1 then
+            require("nvim-tree.api").tree.change_root(name)
+       end
+    end}
 }
 
 return explorer


### PR DESCRIPTION
Muscle memory on `:e .` and `:e ~/`. Used to work on previous version of Doom, but only shows an error message `. is a directory` on 4.0.x.
This was handled by `netrw` which is now entirely disabled (to optimize startup time I assume).

First of all, when the `netrw` feature is used instead of `explorer` we shouldn't disable loading netrw :)
Next, when explorer is used an autocommand is needed to toggle loading it when editing directories. This wouldn't be needed if its `setup()` function was run, but the module is lazy-loaded to decrease startup time, so we need this autocmd.

See `:h nvim-tree-api` (after loading nvim-tree, e.g. by editing a dir) for a stable way to call nvim-tree functions.