### PR TITLE
fix(statusline): increase contrast

### DIFF
--- a/lua/doom/modules/features/statusline/init.lua
+++ b/lua/doom/modules/features/statusline/init.lua
@@ -60,6 +60,9 @@ statusline._safe_get_highlight = function(...)
       local id = vim.fn.synIDtrans(vim.api.nvim_get_hl_id_by_name(hlname))
       local foreground = vim.fn.synIDattr(id, "fg")
       local background = vim.fn.synIDattr(id, "bg")
+      if vim.fn.synIDattr(id, "reverse") == "1" then
+        foreground, background = background, foreground
+      end
       if foreground and foreground:find("^#") then
         return { foreground = foreground, background = background }
       end


### PR DESCRIPTION
Some colorschemes (e.g. Zenburn) have a light foreground for the
statusline, and most of the special* colors are light too, resulting in
very low contrast.
In such a case swap statusline background/foreground colors.

This makes `ZenBurn` theme's statusline readable, even though it doesn't use the statusline colors the theme intended.
This is more of a workaround, but works for me so far. 
Perhaps a better way would be to avoid using so many other colors that were not intended for the statusline and instead try to just tweak the bold/etc. attributes? What do you think?

FWIW with the previous version of Doom the statusline worked without needing to tweak colors.