### PR TITLE
feat(langs,nix): Add nix language support

### DIFF
--- a/doc/doom_nvim_modules.norg
+++ b/doc/doom_nvim_modules.norg
@@ -103,6 +103,7 @@ version: 0.0.11
   - {@ ../lua/doom/modules/langs/kotlin/init.lua}[`kotlin`]
   - {@ ../lua/doom/modules/langs/java/init.lua}[`java`]
   - {@ ../lua/doom/modules/langs/go/init.lua}[`go`]
+  - {@ ../lua/doom/modules/langs/nix/init.lua}[`nix`]
   - {@ ../lua/doom/modules/langs/config/init.lua}[`config`] Adds JSON, YAML, TOML support
   - Missing a language? Submit a feature request issue.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -103,6 +103,7 @@ Modules are grouped into 3 categories:
 - [`kotlin`](../lua/doom/modules/langs/kotlin)
 - [`java`](../lua/doom/modules/langs/java)
 - [`go`](../lua/doom/modules/langs/go)
+- [`nix`](../lua/doom/modules/langs/nix/init.lua)
 - [`config`](../lua/doom/modules/langs/config) Adds JSON, YAML, TOML support
 - Missing a language? Submit a feature request issue.
 

--- a/lua/doom/modules/langs/nix/init.lua
+++ b/lua/doom/modules/langs/nix/init.lua
@@ -1,0 +1,55 @@
+local nix = {}
+
+nix.settings = {
+  formatter = "nixpkgs_fmt",
+  code_actions = {
+    statix = true,
+  },
+  diagnostic = {
+    statix = true,
+    deadnix = true,
+  },
+}
+
+nix.autocmds = {
+  {
+    "BufWinEnter",
+    "*.nix",
+    function()
+      local utils = require("doom.utils")
+      local langs_utils = require("doom.modules.langs.utils")
+
+      require("nvim-treesitter.install").ensure_installed("nix")
+
+      langs_utils.use_lsp("rnix-lsp")
+
+      -- Setup null-ls
+      if utils.is_module_enabled("features", "linter") then
+        local null_ls = require("null-ls")
+
+        local null_ls_source = {}
+
+        if null_ls.builtins.formatting[nix.settings.formatter] then
+          table.insert(null_ls_source, null_ls.builtins.formatting[nix.settings.formatter])
+        end
+
+        if nix.settings.code_actions.statix then
+          table.insert(null_ls_source, null_ls.builtins.code_actions.statix)
+        end
+
+        if nix.settings.diagnostic.statix then
+          table.insert(null_ls_source, null_ls.builtins.diagnostics.statix)
+        end
+
+        if nix.settings.diagnostic.deadnix then
+          table.insert(null_ls_source, null_ls.builtins.diagnostics.deadnix)
+        end
+
+        langs_utils.use_null_ls_source(null_ls_source)
+      end
+    end,
+    once = true,
+  },
+}
+
+return nix

--- a/modules.lua
+++ b/modules.lua
@@ -86,6 +86,7 @@ return {
     -- "markdown",
     -- "terraform",       -- Terraform / hcl files support
     -- "dockerfile",
+    -- "nix",             -- Nix declarations
   },
 }
 


### PR DESCRIPTION
Uses [`rnix-lsp`](https://github.com/nix-community/rnix-lsp) as language-server for Nix files.

For Nix users the `rnix-lsp` is available on nixpkgs.

Enabling the linter feature enable the following:
- Code Actions and diagnostics using `statix`
- Diagnostics using `deadnix` for dead code
- Formatting using `nixpkgs-fmt`

All of those binaries are also available on nixpkgs and can be individaually disables (or switched in the case of `nixpkgs-fmt`)