### PR TITLE
fix(dashboard): Fix shortcuts shown on dashboard

### DIFF
--- a/lua/doom/modules/core/doom/init.lua
+++ b/lua/doom/modules/core/doom/init.lua
@@ -154,6 +154,11 @@ required.binds = function()
             ("<cmd>e %s<CR>"):format(require("doom.core.modules").source),
             name = "Edit modules",
           },
+          {
+            "d",
+            require('doom.core.functions').open_docs,
+            name = "Open documentation",
+          },
           { "l", "<cmd>DoomReload<CR>", name = "Reload config" },
           { "r", "<cmd>DoomRollback<CR>", name = "Rollback" },
           { "R", "<cmd>DoomReport<CR>", name = "Report issue" },

--- a/lua/doom/modules/features/dashboard/init.lua
+++ b/lua/doom/modules/features/dashboard/init.lua
@@ -89,7 +89,7 @@ dashboard.configs["dashboard-nvim"] = function()
     doom.features.dashboard.settings.entries.a = {
       icon = "  ",
       desc = "Load Last Session              ",
-      shortcut = "SPC s r",
+      shortcut = "SPC q r",
       action = "lua require('persistence').load({ last = true })",
     }
   end


### PR DESCRIPTION
- The "Open Documentation" item on the dashboard show the shortcut `SPC D d`, but that shortcut is not set.
- The "Load Last Session" item shows the shortcut `SPC s r`, that shortcut is to continue the last _search_, not session. The last session is `SPC q r`