### PR TITLE
fix(comments): Update plugin call convention

### DIFF
--- a/lua/doom/modules/features/comment/init.lua
+++ b/lua/doom/modules/features/comment/init.lua
@@ -66,29 +66,29 @@ end
 comment.binds = {
   {
     "gc",
-    [[<cmd>lua require("Comment.api").call("toggle_linewise_op")<CR>g@]],
+    [[<cmd>lua require("Comment.api").call("toggle.linewise")<CR>g@]],
     name = "Comment motion",
   },
   {
     "gc",
-    [[<Esc><cmd>lua require("Comment.api").toggle_linewise_op(vim.fn.visualmode())<CR>]],
+    [[<Esc><cmd>lua require("Comment.api").toggle.linewise(vim.fn.visualmode())<CR>]],
     name = "Comment line",
     mode = "v",
   },
   {
     "gb",
-    [[<Esc><cmd>lua require("Comment.api").toggle_blockwise_op(vim.fn.visualmode())<CR>]],
+    [[<Esc><cmd>lua require("Comment.api").toggle.blockwise(vim.fn.visualmode())<CR>]],
     name = "Comment block",
     mode = "v",
   },
   {
     "gcc",
-    [[<cmd>lua require("Comment.api").call("toggle_current_linewise_op")<CR>g@$]],
+    [[<cmd>lua require("Comment.api").call("toggle.linewise.current")<CR>g@$]],
     name = "Comment line",
   },
   {
     "gcA",
-    [[<cmd>lua require("Comment.api").insert_linewise_eol()<CR>]],
+    [[<cmd>lua require("Comment.api").insert.linewise.eol()<CR>]],
     name = "Comment end of line",
   },
 }


### PR DESCRIPTION
The call convention for the `Comment.nvim` plugin has changed on the latest version.

Previously the methods were flattened in the required object with `_` separators, now they are organized in a nested structure using metatables.

- Added upstream on numToStr/Comment.nvim#183