### PR TITLE
feat(auto_install): Switch from nvim-lsp-installer to mason.nvim + various other improvements.

### DIFF
--- a/lua/doom/core/doom_global.lua
+++ b/lua/doom/core/doom_global.lua
@@ -192,14 +192,8 @@ doom = {
 
   -- Logging level
   -- Set Doom logging level
-  -- Available levels:
-  --   · trace
-  --   · debug
-  --   · info
-  --   · warn
-  --   · error
-  --   · fatal
-  -- @default = 'info'
+  -- @default = "info"
+  --- @type "trace"|"debug"|"info"|"warn"|"error"|"fatal"
   logging = "info",
 
   -- Default colorscheme

--- a/lua/doom/core/functions.lua
+++ b/lua/doom/core/functions.lua
@@ -178,9 +178,8 @@ end
 -- Set the indent and tab related numbers.
 -- Negative numbers mean tabstop -- Really though? Tabs?
 functions.set_indent = function()
-  local indent = tonumber(
-    vim.fn.input("Set indent (>0 uses spaces, <0 uses tabs, 0 uses vim defaults): ")
-  )
+  local indent =
+    tonumber(vim.fn.input("Set indent (>0 uses spaces, <0 uses tabs, 0 uses vim defaults): "))
   if not indent then
     indent = -8
   end
@@ -257,7 +256,7 @@ end
 functions.nuke = function(target)
   if target == nil or #target == 0 then
     vim.notify(
-      "Warning, this command deletes packer caches and causes a re-install of doom-nvim on next launch.\n\n :DoomNuke `plugins`|`cache`|`all`. \n\t `cache` - Clear packer_compiled.lua\n\t `plugins` - Clear all installed plugins\n\t `all` - Delete all of the above."
+      "Warning, this command deletes packer caches and causes a re-install of doom-nvim on next launch.\n\n :DoomNuke plugins|cache|mason|all. \n\t `cache` - Clear packer_compiled.lua\n\t `plugins` - Clear all installed plugins\n\t `mason` - Clear all Mason.nvim packages\n\t `all` - Delete all of the above."
     )
     return
   end
@@ -275,6 +274,13 @@ functions.nuke = function(target)
     local plugin_dir = util.join_paths(vim.fn.stdpath("data"), "site", "pack")
     fs.rm_dir(plugin_dir)
     log.info("DoomNuke: Deleting packer plugins.  Doom-nvim will re-install on next launch.")
+  end
+
+  if target == "all" or target == "mason" then
+    local util = require("packer.util")
+    local mason_dir = util.join_paths(vim.fn.stdpath("data"), "mason")
+    fs.rm_dir(mason_dir)
+    log.info("DoomNuke: Deleting mason packages")
   end
 end
 

--- a/lua/doom/modules/core/doom/init.lua
+++ b/lua/doom/modules/core/doom/init.lua
@@ -154,6 +154,11 @@ required.binds = function()
             ("<cmd>e %s<CR>"):format(require("doom.core.modules").source),
             name = "Edit modules",
           },
+          {
+            "d",
+            require('doom.core.functions').open_docs,
+            name = "Open documentation",
+          },
           { "l", "<cmd>DoomReload<CR>", name = "Reload config" },
           { "r", "<cmd>DoomRollback<CR>", name = "Rollback" },
           { "R", "<cmd>DoomReport<CR>", name = "Report issue" },

--- a/lua/doom/modules/core/doom/init.lua
+++ b/lua/doom/modules/core/doom/init.lua
@@ -1,5 +1,3 @@
-local system = require("doom.core.system")
-
 local required = {}
 
 required.settings = {

--- a/lua/doom/modules/features/auto_install/init.lua
+++ b/lua/doom/modules/features/auto_install/init.lua
@@ -1,31 +1,8 @@
+--- Auto installer module
+--- Most logic for this module is inside of `lua/doom/modules/langs/utils`
 local auto_install = {}
 
-auto_install.settings = {
-  lsp_dir = nil, -- Change to a custom path such as `vim.fn.stdpath("data") .. "/lsp-install"`
-  dap_dir = nil, -- Change to a custom path such as `vim.fn.stdpath("data") .. "/dap-install"`
-}
-
-local is_module_enabled = require("doom.utils").is_module_enabled
-
 auto_install.packages = {
-  ["DAPInstall.nvim"] = {
-    "Pocco81/DAPInstall.nvim",
-    commit = "24923c3819a450a772bb8f675926d530e829665f",
-    -- after = "nvim-dap",
-    cmd = {
-      "DIInstall",
-      "DIList",
-      "DIUninstall",
-    },
-    disabled = not is_module_enabled("features", "dap"),
-    module = "dap-install",
-    disable = true,
-  },
-  ["nvim-lsp-installer"] = {
-    "williamboman/nvim-lsp-installer",
-    commit = "ae913cb4fd62d7a84fb1582e11f2e15b4d597123",
-    -- disabled = not is_module_enabled("features", "lsp"),
-  },
   ["mason.nvim"] = {
     "williamboman/mason.nvim",
     commit = "75860d253f9e66d08c9289dc43fae790882eb136",
@@ -37,18 +14,6 @@ auto_install.packages = {
 }
 
 auto_install.configs = {}
-auto_install.configs["nvim-lsp-installer"] = function()
-  local lsp_installer = require("nvim-lsp-installer")
-  lsp_installer.settings({
-    install_root_dir = doom.features.auto_install.settings.lsp_dir,
-  })
-end
-auto_install.configs["DAPInstall.nvim"] = function()
-  local dap_install = require("dap-install")
-  dap_install.setup({
-    installation_path = doom.features.auto_install.settings.dap_dir,
-  })
-end
 auto_install.configs["mason.nvim"] = function()
   require("mason").setup()
 end

--- a/lua/doom/modules/features/auto_install/init.lua
+++ b/lua/doom/modules/features/auto_install/init.lua
@@ -26,6 +26,14 @@ auto_install.packages = {
     commit = "ae913cb4fd62d7a84fb1582e11f2e15b4d597123",
     -- disabled = not is_module_enabled("features", "lsp"),
   },
+  ["mason.nvim"] = {
+    "williamboman/mason.nvim",
+    commit = "75860d253f9e66d08c9289dc43fae790882eb136",
+  },
+  ["mason-lspconfig"] = {
+    "williamboman/mason-lspconfig",
+    commit = "b70dedab5ceb5f3f84c6bc9ceea013292a14f8dc",
+  },
 }
 
 auto_install.configs = {}
@@ -40,6 +48,9 @@ auto_install.configs["DAPInstall.nvim"] = function()
   dap_install.setup({
     installation_path = doom.features.auto_install.settings.dap_dir,
   })
+end
+auto_install.configs["mason.nvim"] = function()
+  require("mason").setup()
 end
 
 return auto_install

--- a/lua/doom/modules/features/dashboard/init.lua
+++ b/lua/doom/modules/features/dashboard/init.lua
@@ -89,7 +89,7 @@ dashboard.configs["dashboard-nvim"] = function()
     doom.features.dashboard.settings.entries.a = {
       icon = "  ",
       desc = "Load Last Session              ",
-      shortcut = "SPC s r",
+      shortcut = "SPC q r",
       action = "lua require('persistence').load({ last = true })",
     }
   end

--- a/lua/doom/modules/langs/bash/init.lua
+++ b/lua/doom/modules/langs/bash/init.lua
@@ -55,13 +55,12 @@ bash.settings = {
   code_actions_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 bash.autocmds = {
   {
     "FileType",
-    "bash",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    "bash,sh",
+    langs_utils.wrap_language_setup("bash", function()
       if not bash.settings.disable_lsp then
         langs_utils.use_lsp_mason(bash.settings.language_server_name)
       end
@@ -91,7 +90,7 @@ bash.autocmds = {
           bash.settings.code_actions_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/bash/init.lua
+++ b/lua/doom/modules/langs/bash/init.lua
@@ -1,30 +1,95 @@
 local bash = {}
 
 bash.settings = {
+  --- disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "bash",
+
+  --- disables default lsp config
+  --- @type boolean
+  disable_lsp = false,
+  --- name of the language server
+  --- @type string
   language_server_name = "bashls",
+
+  --- disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "shfmt",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.shfmt",
+  --- function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "shellcheck",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.shellcheck",
+  --- function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
+  --- disables null-ls diagnostic sources
+  --- @type boolean
+  disable_code_actions = false,
+  --- mason.nvim package to auto install the code_actions provider from
+  --- @type string
+  code_actions_package = "shellcheck",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  code_actions_provider = "builtins.code_actions.shellcheck",
+  --- function to configure null-ls code_actions
+  --- @type function|nil
+  code_actions_config = nil,
 }
 
 bash.autocmds = {
   {
-    "BufWinEnter",
-    "*.sh",
+    "FileType",
+    "bash",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.bash.settings.language_server_name)
 
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("bash")
-      end, 0)
+      if not bash.settings.disable_lsp then
+        langs_utils.use_lsp_mason(bash.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not bash.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(bash.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.shfmt,
-          null_ls.builtins.code_actions.shellcheck,
-          null_ls.builtins.diagnostics.shellcheck,
-        })
+      if not bash.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          bash.settings.formatting_package,
+          bash.settings.formatting_provider,
+          bash.settings.formatting_config
+        )
+      end
+      if not bash.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          bash.settings.diagnostics_package,
+          bash.settings.diagnostics_provider,
+          bash.settings.diagnostics_config
+        )
+      end
+      if not bash.settings.disable_code_actions then
+        langs_utils.use_null_ls(
+          bash.settings.code_actions_package,
+          bash.settings.code_actions_provider,
+          bash.settings.code_actions_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/c_sharp/init.lua
+++ b/lua/doom/modules/langs/c_sharp/init.lua
@@ -29,24 +29,26 @@ c_sharp.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 c_sharp.autocmds = {
   {
     "FileType",
     "cs,vb",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
+    langs_utils.wrap_language_setup("c_sharp", function()
+      vim.cmd("packadd nvim-lspconfig")
 
       if not c_sharp.settings.disable_lsp then
-      local lsp_util = require("lspconfig.util")
+        local lsp_util = require("lspconfig.util")
         langs_utils.use_lsp_mason(c_sharp.settings.language_server_name, {
-        config = {
-          root_dir = function(fname)
-            return lsp_util.root_pattern("*.sln")(fname)
-              or lsp_util.root_pattern("*.csproj")(fname)
-              or lsp_util.root_pattern("ProjectSettings")(fname) -- Add support for unity projects
-          end,
-        },
-      })
+          config = {
+            cmd = { c_sharp.settings.language_server_name },
+            root_dir = function(fname)
+              return lsp_util.root_pattern("*.sln")(fname)
+                or lsp_util.root_pattern("*.csproj")(fname)
+                or lsp_util.root_pattern("ProjectSettings")(fname) -- Add support for unity projects
+            end,
+          },
+        })
       end
 
       if not c_sharp.settings.disable_treesitter then
@@ -60,7 +62,7 @@ c_sharp.autocmds = {
           c_sharp.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/c_sharp/init.lua
+++ b/lua/doom/modules/langs/c_sharp/init.lua
@@ -1,17 +1,44 @@
 local c_sharp = {}
 
 c_sharp.settings = {
+  --- disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "c_sharp",
+
+  --- disables default lsp config
+  --- @type boolean
+  disable_lsp = false,
+  --- name of the language server
+  --- @type string
   language_server_name = "omnisharp",
+
+  --- disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "csharpier",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.csharpier",
+  --- function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
 }
 
 c_sharp.autocmds = {
   {
-    "BufWinEnter",
-    "*.cs",
+    "FileType",
+    "cs,vb",
     function()
       local langs_utils = require("doom.modules.langs.utils")
+
+      if not c_sharp.settings.disable_lsp then
       local lsp_util = require("lspconfig.util")
-      langs_utils.use_lsp(doom.langs.c_sharp.settings.language_server_name, {
+        langs_utils.use_lsp_mason(c_sharp.settings.language_server_name, {
         config = {
           root_dir = function(fname)
             return lsp_util.root_pattern("*.sln")(fname)
@@ -20,8 +47,19 @@ c_sharp.autocmds = {
           end,
         },
       })
+      end
 
-      require("nvim-treesitter.install").ensure_installed("c_sharp")
+      if not c_sharp.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(c_sharp.settings.treesitter_grammars)
+      end
+
+      if not c_sharp.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          c_sharp.settings.formatting_package,
+          c_sharp.settings.formatting_provider,
+          c_sharp.settings.formatting_config
+        )
+      end
     end,
     once = true,
   },

--- a/lua/doom/modules/langs/cc/init.lua
+++ b/lua/doom/modules/langs/cc/init.lua
@@ -8,7 +8,7 @@ cc.settings = {
   disable_treesitter = false,
   --- treesitter grammars to install
   --- @type string|string[]
-  treesitter_grammars = {"c", "cpp"},
+  treesitter_grammars = { "c", "cpp" },
 
   --- disables default lsp config
   --- @type boolean
@@ -20,12 +20,12 @@ cc.settings = {
   --- disables null-ls formatting sources
   --- @type boolean
   disable_formatting = false,
-  --- WARN: No package yet.  mason.nvim package to auto install the formatter from
+  ---Mason.nvim package to auto install the formatter from.
   --- @type string
-  formatting_package = nil,
+  formatting_package = "clang-format",
   --- string to access the null_ls diagnositcs provider
   --- @type string
-  formatting_provider = "builtins.formatting.cppcheck",
+  formatting_provider = "builtins.formatting.clang_format",
   --- function to configure null-ls formatter
   --- @type function|nil
   formatting_config = nil,
@@ -44,15 +44,20 @@ cc.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 cc.autocmds = {
   {
     "FileType",
     "cpp,c",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("cc", function()
       if not cc.settings.disable_lsp then
-        langs_utils.use_lsp_mason(cc.settings.language_server_name)
+        langs_utils.use_lsp_mason(cc.settings.language_server_name, {
+          config = {
+            capabilities = {
+              offsetEncoding = { "utf-16" },
+            }
+          }
+        })
       end
 
       if not cc.settings.disable_treesitter then
@@ -73,7 +78,7 @@ cc.autocmds = {
           cc.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/cc/init.lua
+++ b/lua/doom/modules/langs/cc/init.lua
@@ -1,28 +1,77 @@
 local utils = require("doom.utils")
+
 local cc = {}
 
 cc.settings = {
+  --- disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = {"c", "cpp"},
+
+  --- disables default lsp config
+  --- @type boolean
+  disable_lsp = false,
+  --- name of the language server
+  --- @type string
   language_server_name = utils.get_sysname() == "Darwin" and "clangd" or "ccls",
+
+  --- disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package yet.  mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = nil,
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.cppcheck",
+  --- function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "cpplint",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.cpplint",
+  --- function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 cc.autocmds = {
   {
-    "BufWinEnter",
-    "*.cpp,*.cc,*.cxx,*.c,*.hpp,*.hh,*.hxx,*.h",
+    "FileType",
+    "cpp,c",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.cc.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("cpp", "c")
+      if not cc.settings.disable_lsp then
+        langs_utils.use_lsp_mason(cc.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.modules.linter then
-        local null_ls = require("null-ls")
+      if not cc.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(cc.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.diagnostics.cppcheck,
-          null_ls.builtins.formatting.clang_format,
-        })
+      if not cc.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          cc.settings.formatting_package,
+          cc.settings.formatting_provider,
+          cc.settings.formatting_config
+        )
+      end
+      if not cc.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          cc.settings.diagnostics_package,
+          cc.settings.diagnostics_provider,
+          cc.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/config/init.lua
+++ b/lua/doom/modules/langs/config/init.lua
@@ -1,68 +1,8 @@
+local log = require('doom.utils.logging')
+
+log.warn("The `config` language module is deprecated, please use `json`, `yaml` or `toml`.")
+-- TODO: Delete this file in 1-2 months (written: 25/09/22)
+
 local config = {}
-
--- TODO: Investigate broken yaml/toml language servers
-
-config.settings = {
-  json_schemas = {
-    ".eslintrc",
-    "package.json",
-    "prettierrc.json",
-    "tsconfig.json",
-  },
-  json_language_server_name = "jsonls",
-  -- toml_language_server_name = 'taplo', -- Currently broken
-  -- yaml_language_server_name = 'yamlls', -- Currently broken
-}
-
-config.packages = {
-  ["SchemaStore.nvim"] = {
-    "b0o/SchemaStore.nvim",
-    commit = "f55842dc797faad8cf7b0d9ce75c59da654aa018",
-    ft = { "json", "yaml", "toml" },
-  },
-}
-config.configs = {}
-config.configs["SchemaStore.nvim"] = function()
-  local langs_utils = require("doom.modules.langs.utils")
-  langs_utils.use_lsp(doom.langs.config.settings.json_language_server_name, {
-    config = {
-      settings = {
-        json = {
-          schemas = require("schemastore").json.schemas({
-            select = doom.langs.config.settings.json_schemas,
-          }),
-        },
-      },
-    },
-  })
-end
-
-config.autocmds = {
-  {
-    "BufWinEnter",
-    "*.json,*.yaml,*.toml",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-      -- langs_utils.use_lsp(doom.langs.config.settings.toml_language_server_name)
-      -- langs_utils.use_lsp(doom.langs.config.settings.yaml_language_server_name)
-
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("json5", "yaml", "toml")
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          -- null_ls.builtins.formatting.taplo,
-          -- null_ls.builtins.diagnostics.yamllint,
-          null_ls.builtins.diagnostics.jsonlint,
-        })
-      end
-    end,
-    once = true,
-  },
-}
-
 return config
+

--- a/lua/doom/modules/langs/css/init.lua
+++ b/lua/doom/modules/langs/css/init.lua
@@ -1,7 +1,46 @@
 local css = {}
 
 css.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "css",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "cssls",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "stylelint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.stylelint",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "stylelint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.stylelint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
 }
 
 css.autocmds = {
@@ -10,20 +49,28 @@ css.autocmds = {
     "css,scss,vue,svelte,html",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.css.settings.language_server_name)
 
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("css")
-      end, 0)
+      if not css.settings.disable_lsp then
+        langs_utils.use_lsp_mason(css.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not css.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(css.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.diagnostics.stylelint,
-          null_ls.builtins.formatting.stylelint,
-        })
+      if not css.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          css.settings.formatting_package,
+          css.settings.formatting_provider,
+          css.settings.formatting_config
+        )
+      end
+      if not css.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          css.settings.diagnostics_package,
+          css.settings.diagnostics_provider,
+          css.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/css/init.lua
+++ b/lua/doom/modules/langs/css/init.lua
@@ -20,7 +20,7 @@ css.settings = {
   disable_formatting = false,
   --- Mason.nvim package to auto install the formatter from
   --- @type string
-  formatting_package = "stylelint",
+  formatting_package = "stylelint-lsp",
   --- String to access the null_ls diagnositcs provider
   --- @type string
   formatting_provider = "builtins.formatting.stylelint",
@@ -33,7 +33,7 @@ css.settings = {
   disable_diagnostics = false,
   --- Mason.nvim package to auto install the diagnostics provider from
   --- @type string
-  diagnostics_package = "stylelint",
+  diagnostics_package = "stylelint-lsp",
   --- String to access the null_ls diagnositcs provider
   --- @type string
   diagnostics_provider = "builtins.diagnostics.stylelint",
@@ -43,13 +43,12 @@ css.settings = {
 
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 css.autocmds = {
   {
     "FileType",
     "css,scss,vue,svelte,html",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("css", function()
       if not css.settings.disable_lsp then
         langs_utils.use_lsp_mason(css.settings.language_server_name)
       end
@@ -72,7 +71,7 @@ css.autocmds = {
           css.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/dockerfile/init.lua
+++ b/lua/doom/modules/langs/dockerfile/init.lua
@@ -29,13 +29,12 @@ dockerfile.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 dockerfile.autocmds = {
   {
     "FileType",
     "dockerfile",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("dockerfile", function()
       if not dockerfile.settings.disable_lsp then
         langs_utils.use_lsp_mason(dockerfile.settings.language_server_name)
       end
@@ -51,7 +50,7 @@ dockerfile.autocmds = {
           dockerfile.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/dockerfile/init.lua
+++ b/lua/doom/modules/langs/dockerfile/init.lua
@@ -1,12 +1,32 @@
 local dockerfile = {}
 
 dockerfile.settings = {
-  --- Enable/Disable linting via hadolint
+  --- Disables auto installing the treesitter
   --- @type boolean
-  disable_linter = true,
-  --- Language server name
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "dockerfile",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
   --- @type string
   language_server_name = "dockerls",
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "hadolint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.hadolint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 dockerfile.autocmds = {
@@ -14,21 +34,22 @@ dockerfile.autocmds = {
     "FileType",
     "dockerfile",
     function()
-      local settings = doom.langs.dockerfile.settings
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(settings.language_server_name)
 
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("dockerfile")
-      end, 0)
+      if not dockerfile.settings.disable_lsp then
+        langs_utils.use_lsp_mason(dockerfile.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter and not settings.disable_linter then
-        local null_ls = require("null-ls")
+      if not dockerfile.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(dockerfile.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.diagnostics.hadolint,
-        })
+      if not dockerfile.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          dockerfile.settings.diagnostics_package,
+          dockerfile.settings.diagnostics_provider,
+          dockerfile.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/fish/init.lua
+++ b/lua/doom/modules/langs/fish/init.lua
@@ -1,21 +1,71 @@
 local fish = {}
 
-fish.settings = {}
+fish.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "fish",
+
+  -- --- Disables default LSP config
+  -- --- @type boolean
+  -- disable_lsp = false,
+  -- --- Name of the language server
+  -- --- @type string
+  -- language_server_name = "tsserver",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package yet.  Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.fish_indent",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type nil
+  diagnostics_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.fish",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+}
+
 fish.autocmds = {
   {
-    "BufWinEnter",
-    "*.fish",
+    "FileType",
+    "fish",
     function()
-      require("nvim-treesitter.install").ensure_installed("fish")
+      local langs_utils = require("doom.modules.langs.utils")
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-        local langs_utils = require("doom.modules.langs.utils")
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.fish_indent,
-          null_ls.builtins.diagnostics.fish,
-        })
+      if not fish.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(fish.settings.treesitter_grammars)
+      end
+
+      if not fish.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          fish.settings.formatting_package,
+          fish.settings.formatting_provider,
+          fish.settings.formatting_config
+        )
+      end
+      if not fish.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          fish.settings.diagnostics_package,
+          fish.settings.diagnostics_provider,
+          fish.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/fish/init.lua
+++ b/lua/doom/modules/langs/fish/init.lua
@@ -42,13 +42,12 @@ fish.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 fish.autocmds = {
   {
     "FileType",
     "fish",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("fish", function()
       if not fish.settings.disable_treesitter then
         langs_utils.use_tree_sitter(fish.settings.treesitter_grammars)
       end
@@ -67,7 +66,7 @@ fish.autocmds = {
           fish.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/gdscript/init.lua
+++ b/lua/doom/modules/langs/gdscript/init.lua
@@ -42,12 +42,12 @@ gdscript.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 gdscript.autocmds = {
   {
     "BufWinEnter",
     "*.gd",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
+    langs_utils.wrap_language_setup("gdscript", function()
 
       if not gdscript.settings.disable_lsp then
         langs_utils.use_lsp_mason(gdscript.settings.language_server_name, {
@@ -78,7 +78,7 @@ gdscript.autocmds = {
           gdscript.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/gdscript/init.lua
+++ b/lua/doom/modules/langs/gdscript/init.lua
@@ -1,7 +1,45 @@
 local gdscript = {}
 
 gdscript.settings = {
-  language_server_name = "gdscript",
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = { "gdscript", "godot_resource" },
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "tsserver",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package yet. Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.gdformat",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- WARN: No package yet. Mason.nvim package to auto install the diagnostics provider from
+  --- @type nil
+  diagnostics_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.gdlint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 gdscript.autocmds = {
@@ -9,26 +47,37 @@ gdscript.autocmds = {
     "BufWinEnter",
     "*.gd",
     function()
-      print("gdscript")
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.modules.langs.gdscript.settings.language_server_name, {
-        no_installer = true,
-        config = {
-          flags = {
-            debounce_text_changes = 150,
-          },
-        },
-      })
-      if doom.features.linter then
-        local null_ls = require("null-ls")
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.gdformat,
-          null_ls.builtins.diagnostics.gdlint,
+      if not gdscript.settings.disable_lsp then
+        langs_utils.use_lsp_mason(gdscript.settings.language_server_name, {
+          no_installer = true,
+          config = {
+            flags = {
+              debounce_text_changes = 150,
+            },
+          },
         })
       end
 
-      require("nvim-treesitter.install").ensure_installed("gdscript", "godot_resource")
+      if not gdscript.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(gdscript.settings.treesitter_grammars)
+      end
+
+      if not gdscript.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          gdscript.settings.formatting_package,
+          gdscript.settings.formatting_provider,
+          gdscript.settings.formatting_config
+        )
+      end
+      if not gdscript.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          gdscript.settings.diagnostics_package,
+          gdscript.settings.diagnostics_provider,
+          gdscript.settings.diagnostics_config
+        )
+      end
     end,
     once = true,
   },

--- a/lua/doom/modules/langs/glsl/init.lua
+++ b/lua/doom/modules/langs/glsl/init.lua
@@ -33,12 +33,12 @@ glsl.settings = {
   end,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 glsl.autocmds = {
   {
     "FileType",
     "glsl",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
+    langs_utils.wrap_language_setup("glsl", function()
 
       -- if not glsl.settings.disable_lsp then
       --   langs_utils.use_lsp_mason(glsl.settings.language_server_name)
@@ -55,7 +55,7 @@ glsl.autocmds = {
           glsl.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
   -- TODO: Refactor to use filetype.lua or filetype.vim

--- a/lua/doom/modules/langs/glsl/init.lua
+++ b/lua/doom/modules/langs/glsl/init.lua
@@ -1,36 +1,71 @@
 local glsl = {}
 
-glsl.settings = {}
+glsl.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "glsl",
+
+  -- --- Disables default LSP config
+  -- --- @type boolean
+  -- disable_lsp = false,
+  -- --- Name of the language server
+  -- --- @type string
+  -- language_server_name = "tsserver",
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- WARN: No package.  Mason.nvim package to auto install the diagnostics provider from
+  --- @type nil
+  diagnostics_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.glslc",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = function(glslc)
+    glslc.with({
+      extra_args = { "--target-env=opengl" }, -- use opengl instead of vulkan1.0
+    })
+  end,
+}
 
 glsl.autocmds = {
   {
     "FileType",
     "glsl",
     function()
-      pcall(function()
-        local langs_utils = require("doom.modules.langs.utils")
+      local langs_utils = require("doom.modules.langs.utils")
 
-        require("nvim-treesitter.install").ensure_installed("glsl")
+      -- if not glsl.settings.disable_lsp then
+      --   langs_utils.use_lsp_mason(glsl.settings.language_server_name)
+      -- end
 
-        -- Setup null-ls
-        if doom.features.linter then
-          local null_ls = require("null-ls")
+      if not glsl.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(glsl.settings.treesitter_grammars)
+      end
 
-          langs_utils.use_null_ls_source({
-            null_ls.builtins.formatting.shfmt,
-          })
-        end
-      end)
+      if not glsl.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          glsl.settings.diagnostics_package,
+          glsl.settings.diagnostics_provider,
+          glsl.settings.diagnostics_config
+        )
+      end
     end,
     once = true,
   },
+  -- TODO: Refactor to use filetype.lua or filetype.vim
   {
     "BufWinEnter",
-    "*.glsl,*.vs,*.fs,*.frag,*.vert",
-    function()
-      vim.bo.filetype = "glsl"
-    end,
-  },
+    "*.glsl,*.frag,*.vert,*.fs,*.vs",
+    function ()
+      vim.bo.filetype = 'glsl'
+    end
+  }
 }
 
 return glsl

--- a/lua/doom/modules/langs/go/init.lua
+++ b/lua/doom/modules/langs/go/init.lua
@@ -1,7 +1,45 @@
 local go = {}
 
 go.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "go",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "gopls",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "gofumpt",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.gofumpt",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "golangci_lint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.golangci_lint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 go.autocmds = {
@@ -10,17 +48,28 @@ go.autocmds = {
     "*.go",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.go.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("go")
+      if not go.settings.disable_lsp then
+        langs_utils.use_lsp_mason(go.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not go.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(go.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.diagnostics.golangci_lint,
-        })
+      if not go.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          go.settings.formatting_package,
+          go.settings.formatting_provider,
+          go.settings.formatting_config
+        )
+      end
+      if not go.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          go.settings.diagnostics_package,
+          go.settings.diagnostics_provider,
+          go.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/go/init.lua
+++ b/lua/doom/modules/langs/go/init.lua
@@ -33,7 +33,7 @@ go.settings = {
   disable_diagnostics = false,
   --- Mason.nvim package to auto install the diagnostics provider from
   --- @type string
-  diagnostics_package = "golangci_lint",
+  diagnostics_package = "golangci-lint",
   --- String to access the null_ls diagnositcs provider
   --- @type string
   diagnostics_provider = "builtins.diagnostics.golangci_lint",
@@ -42,12 +42,12 @@ go.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 go.autocmds = {
   {
     "BufWinEnter",
     "*.go",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
+    langs_utils.wrap_language_setup("go", function()
 
       if not go.settings.disable_lsp then
         langs_utils.use_lsp_mason(go.settings.language_server_name)
@@ -71,7 +71,7 @@ go.autocmds = {
           go.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/haskell/init.lua
+++ b/lua/doom/modules/langs/haskell/init.lua
@@ -29,14 +29,14 @@ haskell.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 haskell.autocmds = {
   {
-    "BufWinEnter",
-    "*.hs",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    "FileType",
+    "haskell",
+    langs_utils.wrap_language_setup("haskell", function()
       if not haskell.settings.disable_lsp then
+        print("starting lsp")
         langs_utils.use_lsp_mason(haskell.settings.language_server_name)
       end
 
@@ -58,7 +58,7 @@ haskell.autocmds = {
           haskell.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/haskell/init.lua
+++ b/lua/doom/modules/langs/haskell/init.lua
@@ -1,7 +1,32 @@
 local haskell = {}
 
 haskell.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "haskell",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "hls",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package. Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.fourmolu",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
 }
 
 haskell.autocmds = {
@@ -10,24 +35,28 @@ haskell.autocmds = {
     "*.hs",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.haskell.settings.language_server_name)
 
-      local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-      parser_config.haskell = {
-        install_info = {
-          url = "https://github.com/tree-sitter/tree-sitter-haskell",
-          files = { "src/parser.c", "src/scanner.c" },
-        },
-      }
-      require("nvim-treesitter.install").ensure_installed("haskell")
+      if not haskell.settings.disable_lsp then
+        langs_utils.use_lsp_mason(haskell.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not haskell.settings.disable_treesitter then
+        local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+        parser_config.haskell = {
+          install_info = {
+            url = "https://github.com/tree-sitter/tree-sitter-haskell",
+            files = { "src/parser.c", "src/scanner.c" },
+          },
+        }
+        langs_utils.use_tree_sitter(haskell.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.fouremolu,
-        })
+      if not haskell.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          haskell.settings.diagnostics_package,
+          haskell.settings.formatting_provider,
+          haskell.settings.formatting_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/html/init.lua
+++ b/lua/doom/modules/langs/html/init.lua
@@ -33,13 +33,12 @@ html.settings = {
   end,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 html.autocmds = {
   {
     "BufWinEnter",
     "*.html",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("html", function()
       if not html.settings.disable_lsp then
         langs_utils.use_lsp_mason(html.settings.language_server_name)
       end
@@ -55,7 +54,7 @@ html.autocmds = {
           html.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/html/init.lua
+++ b/lua/doom/modules/langs/html/init.lua
@@ -1,32 +1,61 @@
-local utils = require("doom.utils")
-
 local html = {}
 
-html.settings = {}
+html.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = {"html", "javascript", "css"},
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "html",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "rome",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.rome",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = function(rome)
+    rome.with({
+      filetypes = { "html" }
+    })
+  end,
+}
 
 html.autocmds = {
   {
     "BufWinEnter",
     "*.html",
-    utils.make_run_once_function(function()
-      print("html")
+    function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp("html")
 
-      vim.defer_fn(function()
-        local ts_install = require("nvim-treesitter.install")
-        ts_install.ensure_installed("html", "javascript", "css")
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.tidy,
-        })
+      if not html.settings.disable_lsp then
+        langs_utils.use_lsp_mason(html.settings.language_server_name)
       end
-    end),
+
+      if not html.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(html.settings.treesitter_grammars)
+      end
+
+      if not html.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          html.settings.diagnostics_package,
+          html.settings.formatting_provider,
+          html.settings.formatting_config
+        )
+      end
+    end,
     once = true,
   },
 }

--- a/lua/doom/modules/langs/java/init.lua
+++ b/lua/doom/modules/langs/java/init.lua
@@ -1,7 +1,32 @@
 local java = {}
 
 java.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "java",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "jdtls",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package. Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.google_java_format",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
 }
 
 java.autocmds = {
@@ -10,17 +35,21 @@ java.autocmds = {
     "*.java",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.java.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("java")
+      if not java.settings.disable_lsp then
+        langs_utils.use_lsp_mason(java.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.modules.linter then
-        local null_ls = require("null-ls")
+      if not java.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(java.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.google_java_format,
-        })
+      if not java.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          java.settings.diagnostics_package,
+          java.settings.formatting_provider,
+          java.settings.formatting_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/java/init.lua
+++ b/lua/doom/modules/langs/java/init.lua
@@ -29,12 +29,12 @@ java.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 java.autocmds = {
   {
     "BufWinEnter",
     "*.java",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
+    langs_utils.wrap_language_setup("java", function()
 
       if not java.settings.disable_lsp then
         langs_utils.use_lsp_mason(java.settings.language_server_name)
@@ -51,7 +51,7 @@ java.autocmds = {
           java.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/json/init.lua
+++ b/lua/doom/modules/langs/json/init.lua
@@ -33,17 +33,17 @@ json.packages = {
   ["SchemaStore.nvim"] = {
     "b0o/SchemaStore.nvim",
     commit = "f55842dc797faad8cf7b0d9ce75c59da654aa018",
-    ft = { "json" },
+    ft = "json",
   },
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 json.autocmds = {
   {
     "FileType",
     "json",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("json", function()
+      vim.cmd("packadd SchemaStore.nvim")
       if not json.settings.disable_lsp then
         langs_utils.use_lsp_mason(json.settings.language_server_name, {
           config = {
@@ -67,7 +67,7 @@ json.autocmds = {
           json.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/json/init.lua
+++ b/lua/doom/modules/langs/json/init.lua
@@ -1,0 +1,75 @@
+local json = {}
+
+json.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "json",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "jsonls",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "fixjson",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.fixjson",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+}
+
+json.packages = {
+  ["SchemaStore.nvim"] = {
+    "b0o/SchemaStore.nvim",
+    commit = "f55842dc797faad8cf7b0d9ce75c59da654aa018",
+    ft = { "json" },
+  },
+}
+
+json.autocmds = {
+  {
+    "FileType",
+    "json",
+    function()
+      local langs_utils = require("doom.modules.langs.utils")
+
+      if not json.settings.disable_lsp then
+        langs_utils.use_lsp_mason(json.settings.language_server_name, {
+          config = {
+            settings = {
+              json = {
+                schemas = require("schemastore").json.schemas(),
+              },
+            },
+          },
+        })
+      end
+
+      if not json.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(json.settings.treesitter_grammars)
+      end
+
+      if not json.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          json.settings.diagnostics_package,
+          json.settings.formatting_provider,
+          json.settings.formatting_config
+        )
+      end
+    end,
+    once = true,
+  },
+}
+
+return json

--- a/lua/doom/modules/langs/kotlin/init.lua
+++ b/lua/doom/modules/langs/kotlin/init.lua
@@ -42,13 +42,12 @@ kotlin.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 kotlin.autocmds = {
   {
     "FileType",
     "kotlin",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("kotlin", function()
       if not kotlin.settings.disable_lsp then
         langs_utils.use_lsp_mason(kotlin.settings.language_server_name)
       end
@@ -71,7 +70,7 @@ kotlin.autocmds = {
           kotlin.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/kotlin/init.lua
+++ b/lua/doom/modules/langs/kotlin/init.lua
@@ -1,25 +1,75 @@
 local kotlin = {}
 
 kotlin.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "kotlin",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "kotlin_language_server",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "ktlint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.ktlint",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "ktlint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.ktlint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 kotlin.autocmds = {
   {
-    "BufWinEnter",
-    "*.kt,*.kts",
+    "FileType",
+    "kotlin",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.kotlin.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("kotlin")
-      -- Setup null-ls
-      if doom.modules.linter then
-        local null_ls = require("null-ls")
+      if not kotlin.settings.disable_lsp then
+        langs_utils.use_lsp_mason(kotlin.settings.language_server_name)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.ktlint,
-        })
+      if not kotlin.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(kotlin.settings.treesitter_grammars)
+      end
+
+      if not kotlin.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          kotlin.settings.formatting_package,
+          kotlin.settings.formatting_provider,
+          kotlin.settings.formatting_config
+        )
+      end
+      if not kotlin.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          kotlin.settings.diagnostics_package,
+          kotlin.settings.diagnostics_provider,
+          kotlin.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/lua/init.lua
+++ b/lua/doom/modules/langs/lua/init.lua
@@ -84,13 +84,12 @@ lua.packages = {
   },
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 lua.autocmds = {
   {
     "BufWinEnter",
     "*.lua",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("lua", function()
       local runtime_path = vim.split(package.path, ";")
       table.insert(runtime_path, "lua/?.lua")
       table.insert(runtime_path, "lua/?/init.lua")
@@ -134,7 +133,7 @@ lua.autocmds = {
           lua.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/lua/init.lua
+++ b/lua/doom/modules/langs/lua/init.lua
@@ -86,8 +86,8 @@ lua.packages = {
 
 lua.autocmds = {
   {
-    "FileType",
-    "lua",
+    "BufWinEnter",
+    "*.lua",
     function()
       local langs_utils = require("doom.modules.langs.utils")
 

--- a/lua/doom/modules/langs/lua/init.lua
+++ b/lua/doom/modules/langs/lua/init.lua
@@ -1,29 +1,73 @@
 local lua = {}
 
 lua.settings = {
-  formatter = {
-    enabled = true,
-  },
-  settings = {
-    Lua = {
-      runtime = {
-        version = "LuaJIT",
-      },
-      diagnostics = {
-        globals = { "vim", "doom" },
-      },
-      workspace = {
-        library = vim.api.nvim_get_runtime_file("", true),
-        maxPreload = 1000,
-        preloadFileSize = 150,
-        checkThirdParty = false,
-      },
-      telemetry = {
-        enable = false,
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "lua",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "sumneko_lua",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "stylua",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.stylua",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "luacheck",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.luacheck",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
+  --- Options passed to language server
+  lsp_config = {
+    formatter = {
+      enabled = true,
+    },
+    settings = {
+      Lua = {
+        runtime = {
+          version = "LuaJIT",
+        },
+        diagnostics = {
+          globals = { "vim", "doom" },
+        },
+        workspace = {
+          library = vim.api.nvim_get_runtime_file("", true),
+          maxPreload = 1000,
+          preloadFileSize = 150,
+          checkThirdParty = false,
+        },
+        telemetry = {
+          enable = false,
+        },
       },
     },
   },
-  dev = {
+  --- Config for the lua-dev plugin
+  lua_dev = {
     library = {
       vimruntime = true,
       types = true,
@@ -42,8 +86,8 @@ lua.packages = {
 
 lua.autocmds = {
   {
-    "BufWinEnter",
-    "*.lua",
+    "FileType",
+    "lua",
     function()
       local langs_utils = require("doom.modules.langs.utils")
 
@@ -53,7 +97,7 @@ lua.autocmds = {
 
       local config = vim.tbl_deep_extend(
         "force",
-        doom.langs.lua.settings,
+        doom.langs.lua.settings.lsp_config,
         require("lua-dev").setup(doom.langs.lua.settings.dev),
         {
           settings = {
@@ -66,22 +110,29 @@ lua.autocmds = {
         }
       )
 
-      langs_utils.use_lsp("sumneko_lua", {
-        config = config,
-      })
-
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("lua")
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.stylua,
-          null_ls.builtins.diagnostics.luacheck,
+      if not lua.settings.disable_lsp then
+        langs_utils.use_lsp_mason(lua.settings.language_server_name, {
+          config = config,
         })
+      end
+
+      if not lua.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(lua.settings.treesitter_grammars)
+      end
+
+      if not lua.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          lua.settings.formatting_package,
+          lua.settings.formatting_provider,
+          lua.settings.formatting_config
+        )
+      end
+      if not lua.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          lua.settings.diagnostics_package,
+          lua.settings.diagnostics_provider,
+          lua.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/markdown/init.lua
+++ b/lua/doom/modules/langs/markdown/init.lua
@@ -29,13 +29,12 @@ markdown.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 markdown.autocmds = {
   {
     "FileType",
     "markdown",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("markdown", function()
       if not markdown.settings.disable_lsp then
         langs_utils.use_lsp_mason(markdown.settings.language_server_name)
       end
@@ -51,7 +50,7 @@ markdown.autocmds = {
           markdown.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/markdown/init.lua
+++ b/lua/doom/modules/langs/markdown/init.lua
@@ -1,7 +1,32 @@
 local markdown = {}
 
 markdown.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
   disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "markdown",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "remark_ls",
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "markdownlint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.markdownlint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 markdown.autocmds = {
@@ -9,27 +34,23 @@ markdown.autocmds = {
     "FileType",
     "markdown",
     function()
-      -- local langs_utils = require("doom.modules.langs.utils")
+      local langs_utils = require("doom.modules.langs.utils")
 
-      -- Disabled due to unreliability (only works in projects with `remark`
-      -- npm package installed).
-      -- langs_utils.use_lsp("remark_ls")
+      if not markdown.settings.disable_lsp then
+        langs_utils.use_lsp_mason(markdown.settings.language_server_name)
+      end
 
-      vim.defer_fn(function()
-        if not markdown.settings.disable_treesitter then
-          require("nvim-treesitter.install").ensure_installed("markdown")
-        end
-      end, 0)
+      if not markdown.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(markdown.settings.treesitter_grammars)
+      end
 
-      -- Setup null-ls
-      -- Disabled due to lsp being disabled. null-ls gets triggered by lspconfig
-      -- if doom.modules.linter then
-      --   local null_ls = require("null-ls")
-      --
-      --   langs_utils.use_null_ls_source({
-      --     null_ls.builtins.diagnostics.markdownlint,
-      --   })
-      -- end
+      if not markdown.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          markdown.settings.diagnostics_package,
+          markdown.settings.diagnostics_provider,
+          markdown.settings.diagnostics_config
+        )
+      end
     end,
     once = true,
   },

--- a/lua/doom/modules/langs/markdown/init.lua
+++ b/lua/doom/modules/langs/markdown/init.lua
@@ -1,11 +1,13 @@
 local markdown = {}
 
-markdown.settings = {}
+markdown.settings = {
+  disable_treesitter = false,
+}
 
 markdown.autocmds = {
   {
-    "BufWinEnter",
-    "*.md",
+    "FileType",
+    "markdown",
     function()
       -- local langs_utils = require("doom.modules.langs.utils")
 
@@ -14,7 +16,9 @@ markdown.autocmds = {
       -- langs_utils.use_lsp("remark_ls")
 
       vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("markdown")
+        if not markdown.settings.disable_treesitter then
+          require("nvim-treesitter.install").ensure_installed("markdown")
+        end
       end, 0)
 
       -- Setup null-ls

--- a/lua/doom/modules/langs/nix/init.lua
+++ b/lua/doom/modules/langs/nix/init.lua
@@ -11,17 +11,17 @@ nix.settings = {
   },
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 nix.autocmds = {
   {
     "BufWinEnter",
     "*.nix",
-    function()
+    langs_utils.wrap_language_setup("nix", function()
       local utils = require("doom.utils")
-      local langs_utils = require("doom.modules.langs.utils")
 
       require("nvim-treesitter.install").ensure_installed("nix")
 
-      langs_utils.use_lsp("rnix-lsp")
+      langs_utils.use_lsp_mason("rnix")
 
       -- Setup null-ls
       if utils.is_module_enabled("features", "linter") then
@@ -47,7 +47,7 @@ nix.autocmds = {
 
         langs_utils.use_null_ls_source(null_ls_source)
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/ocaml/init.lua
+++ b/lua/doom/modules/langs/ocaml/init.lua
@@ -1,23 +1,35 @@
 local ocaml = {}
 
 ocaml.settings = {
+  --- disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = {"ocaml", "ocaml_interface", "ocamllex"},
+
+  --- disables default lsp config
+  --- @type boolean
+  disable_lsp = false,
+  --- name of the language server
+  --- @type string
   language_server_name = "ocamllsp",
 }
 
 ocaml.autocmds = {
   {
-    "Filetype",
-    "ocaml,ocaml_interface,ocamllex",
+    "FileType",
+    "ocaml",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.ocaml.settings.language_server_name)
 
-      vim.schedule(function()
-        require("nvim-treesitter.install").ensure_installed("ocaml", "ocaml_interface")
-        if vim.fn.executable("tree-sitter-cli") == 1 then
-          require("nvim-treesitter.install").ensure_installed("ocamllex")
-        end
-      end)
+      if not ocaml.settings.disable_lsp then
+        langs_utils.use_lsp_mason(ocaml.settings.language_server_name)
+      end
+
+      if not ocaml.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(ocaml.settings.treesitter_grammars)
+      end
     end,
     once = true,
   },

--- a/lua/doom/modules/langs/ocaml/init.lua
+++ b/lua/doom/modules/langs/ocaml/init.lua
@@ -16,13 +16,12 @@ ocaml.settings = {
   language_server_name = "ocamllsp",
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 ocaml.autocmds = {
   {
     "FileType",
     "ocaml",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("ocaml", function()
       if not ocaml.settings.disable_lsp then
         langs_utils.use_lsp_mason(ocaml.settings.language_server_name)
       end
@@ -30,7 +29,7 @@ ocaml.autocmds = {
       if not ocaml.settings.disable_treesitter then
         langs_utils.use_tree_sitter(ocaml.settings.treesitter_grammars)
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/php/init.lua
+++ b/lua/doom/modules/langs/php/init.lua
@@ -1,28 +1,82 @@
-local utils = require("doom.utils")
 local php = {}
 
 php.settings = {
+  --- disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "php",
+
+  --- disables default lsp config
+  --- @type boolean
+  disable_lsp = false,
+  --- name of the language server
+  --- @type string
   language_server_name = "intelephense",
+
+  --- disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "php-cs-fixer",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.phpcsfixer",
+  --- function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "phpstan",
+  --- string to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.phpstan",
+  --- function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 php.autocmds = {
   {
-    "BufWinEnter",
-    "*.php,*.phtml",
+    "FileType",
+    "php,phtml",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.php.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("php")
+      if not php.settings.disable_lsp then
+        langs_utils.use_lsp_mason(php.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.modules.linter then
-        local null_ls = require("null-ls")
+      if not php.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(php.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.phpcsfixer,
-          null_ls.builtins.diagnostics.phpstan,
-        })
+      if not php.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          php.settings.formatting_package,
+          php.settings.formatting_provider,
+          php.settings.formatting_config
+        )
+      end
+      if not php.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          php.settings.diagnostics_package,
+          php.settings.diagnostics_provider,
+          php.settings.diagnostics_config
+        )
+      end
+      if not php.settings.disable_code_actions then
+        langs_utils.use_null_ls(
+          php.settings.code_actions_package,
+          php.settings.code_actions_provider,
+          php.settings.code_actions_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/php/init.lua
+++ b/lua/doom/modules/langs/php/init.lua
@@ -42,13 +42,12 @@ php.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 php.autocmds = {
   {
     "FileType",
     "php,phtml",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("php", function()
       if not php.settings.disable_lsp then
         langs_utils.use_lsp_mason(php.settings.language_server_name)
       end
@@ -78,7 +77,7 @@ php.autocmds = {
           php.settings.code_actions_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/python/init.lua
+++ b/lua/doom/modules/langs/python/init.lua
@@ -1,27 +1,75 @@
 local python = {}
 
 python.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "python",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "pyright",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "black",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.black",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "mypy",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.mypy",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 python.autocmds = {
   {
-    "BufWinEnter",
-    "*.py",
+    "FileType",
+    "python",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.python.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("python")
+      if not python.settings.disable_lsp then
+        langs_utils.use_lsp_mason(python.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not python.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(python.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.black,
-          null_ls.builtins.diagnostics.mypy,
-        })
+      if not python.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          python.settings.formatting_package,
+          python.settings.formatting_provider,
+          python.settings.formatting_config
+        )
+      end
+      if not python.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          python.settings.diagnostics_package,
+          python.settings.diagnostics_provider,
+          python.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/python/init.lua
+++ b/lua/doom/modules/langs/python/init.lua
@@ -42,13 +42,12 @@ python.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 python.autocmds = {
   {
     "FileType",
     "python",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("python", function()
       if not python.settings.disable_lsp then
         langs_utils.use_lsp_mason(python.settings.language_server_name)
       end
@@ -71,7 +70,7 @@ python.autocmds = {
           python.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/ruby/init.lua
+++ b/lua/doom/modules/langs/ruby/init.lua
@@ -1,26 +1,55 @@
 local ruby = {}
 
 ruby.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "ruby",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "solargraph",
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "rubocop",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.rubocop",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
 }
 
 ruby.autocmds = {
   {
-    "BufWinEnter",
-    "*.rb",
+    "FileType",
+    "ruby",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.ruby.settings.language_server_name)
 
-      require("nvim-treesitter.install").ensure_installed("ruby")
+      if not ruby.settings.disable_lsp then
+        langs_utils.use_lsp_mason(ruby.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not ruby.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(ruby.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.diagnostics.rubocop,
-        })
+      if not ruby.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          ruby.settings.diagnostics_package,
+          ruby.settings.diagnostics_provider,
+          ruby.settings.diagnostics_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/ruby/init.lua
+++ b/lua/doom/modules/langs/ruby/init.lua
@@ -29,13 +29,12 @@ ruby.settings = {
   diagnostics_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 ruby.autocmds = {
   {
     "FileType",
     "ruby",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("ruby", function()
       if not ruby.settings.disable_lsp then
         langs_utils.use_lsp_mason(ruby.settings.language_server_name)
       end
@@ -51,7 +50,7 @@ ruby.autocmds = {
           ruby.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/rust/init.lua
+++ b/lua/doom/modules/langs/rust/init.lua
@@ -26,3 +26,64 @@ rust.autocmds = {
 }
 
 return rust
+
+
+local rust = {}
+
+rust.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "rust",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "rust_analyzer",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package yet.  Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.rustfmt",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+}
+
+rust.autocmds = {
+  {
+    "FileType",
+    "rust",
+    function()
+      local langs_utils = require("doom.modules.langs.utils")
+
+      if not rust.settings.disable_lsp then
+        langs_utils.use_lsp_mason(rust.settings.language_server_name)
+      end
+
+      if not rust.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(rust.settings.treesitter_grammars)
+      end
+
+      if not rust.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          rust.settings.formatting_package,
+          rust.settings.formatting_provider,
+          rust.settings.formatting_config
+        )
+      end
+    end,
+    once = true,
+  },
+}
+
+return rust

--- a/lua/doom/modules/langs/rust/init.lua
+++ b/lua/doom/modules/langs/rust/init.lua
@@ -1,35 +1,5 @@
 local rust = {}
 
-rust.settings = {}
-
-rust.autocmds = {
-  {
-    "BufWinEnter",
-    "*.rs",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
-      langs_utils.use_lsp("rust_analyzer")
-
-      require("nvim-treesitter.install").ensure_installed("rust")
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.rustfmt,
-        })
-      end
-    end,
-    once = true,
-  },
-}
-
-return rust
-
-
-local rust = {}
-
 rust.settings = {
   --- Disables auto installing the treesitter
   --- @type boolean
@@ -59,13 +29,12 @@ rust.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 rust.autocmds = {
   {
     "FileType",
     "rust",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("rust", function()
       if not rust.settings.disable_lsp then
         langs_utils.use_lsp_mason(rust.settings.language_server_name)
       end
@@ -81,7 +50,7 @@ rust.autocmds = {
           rust.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/svelte/init.lua
+++ b/lua/doom/modules/langs/svelte/init.lua
@@ -55,13 +55,12 @@ svelte.settings = {
   code_actions_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 svelte.autocmds = {
   {
     "FileType",
     "svelte",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("svelte", function()
       if not svelte.settings.disable_lsp then
         langs_utils.use_lsp_mason(svelte.settings.language_server_name)
       end
@@ -91,7 +90,7 @@ svelte.autocmds = {
           svelte.settings.code_actions_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/svelte/init.lua
+++ b/lua/doom/modules/langs/svelte/init.lua
@@ -1,30 +1,95 @@
 local svelte = {}
 
 svelte.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "svelte",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
   language_server_name = "svelte",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.eslint_d",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.eslint_d",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_code_actions = false,
+  --- Mason.nvim package to auto install the code_actions provider from
+  --- @type string
+  code_actions_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  code_actions_provider = "builtins.code_actions.eslint_d",
+  --- Function to configure null-ls code_actions
+  --- @type function|nil
+  code_actions_config = nil,
 }
 
 svelte.autocmds = {
   {
-    "BufWinEnter",
-    "*.svelte",
+    "FileType",
+    "svelte",
     function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp(doom.langs.svelte.settings.language_server_name)
 
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("svelte")
-      end, 0)
+      if not svelte.settings.disable_lsp then
+        langs_utils.use_lsp_mason(svelte.settings.language_server_name)
+      end
 
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
+      if not svelte.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(svelte.settings.treesitter_grammars)
+      end
 
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.eslint_d,
-          null_ls.builtins.code_actions.eslint_d,
-          null_ls.builtins.diagnostics.eslint_d,
-        })
+      if not svelte.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          svelte.settings.diagnostics_package,
+          svelte.settings.formatting_provider,
+          svelte.settings.formatting_config
+        )
+      end
+      if not svelte.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          svelte.settings.diagnostics_package,
+          svelte.settings.diagnostics_provider,
+          svelte.settings.diagnostics_config
+        )
+      end
+      if not svelte.settings.disable_code_actions then
+        langs_utils.use_null_ls(
+          svelte.settings.code_actions_package,
+          svelte.settings.code_actions_provider,
+          svelte.settings.code_actions_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/tailwindcss/init.lua
+++ b/lua/doom/modules/langs/tailwindcss/init.lua
@@ -1,33 +1,59 @@
-local utils = require("doom.utils")
+local typescript = {}
 
-local tailwindcss = {}
+typescript.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = { "css", "html", "vue" },
 
-tailwindcss.settings = {}
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "tailwindcss",
 
-tailwindcss.autocmds = {
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- WARN: No package yet. Mason.nvim package to auto install the formatter from
+  --- @type nil
+  formatting_package = nil,
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.rustywind",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+}
+
+typescript.autocmds = {
   {
-    "BufWinEnter",
-    "*.css,*.scss,*.vue,*.html,*.svelte,*.jsx,*.tsx",
-    utils.make_run_once_function(function()
+    "FileType",
+    "javascript,typescript,javascriptreact,typescriptreact,css,html,vue,svelte",
+    function()
       local langs_utils = require("doom.modules.langs.utils")
 
-      langs_utils.use_lsp("tailwindcss")
-
-      vim.defer_fn(function()
-        require("nvim-treesitter.install").ensure_installed("css")
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.rustywind,
-        })
+      if not typescript.settings.disable_lsp then
+        langs_utils.use_lsp_mason(typescript.settings.language_server_name)
       end
-    end),
+
+      if not typescript.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(typescript.settings.treesitter_grammars)
+      end
+
+      if not typescript.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          typescript.settings.formatting_package,
+          typescript.settings.formatting_provider,
+          typescript.settings.formatting_config
+        )
+      end
+    end,
     once = true,
   },
 }
 
-return tailwindcss
+return typescript

--- a/lua/doom/modules/langs/tailwindcss/init.lua
+++ b/lua/doom/modules/langs/tailwindcss/init.lua
@@ -1,6 +1,6 @@
-local typescript = {}
+local tailwindcss = {}
 
-typescript.settings = {
+tailwindcss.settings = {
   --- Disables auto installing the treesitter
   --- @type boolean
   disable_treesitter = false,
@@ -29,31 +29,30 @@ typescript.settings = {
   formatting_config = nil,
 }
 
-typescript.autocmds = {
+local langs_utils = require("doom.modules.langs.utils")
+tailwindcss.autocmds = {
   {
     "FileType",
     "javascript,typescript,javascriptreact,typescriptreact,css,html,vue,svelte",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
-      if not typescript.settings.disable_lsp then
-        langs_utils.use_lsp_mason(typescript.settings.language_server_name)
+    langs_utils.wrap_language_setup("tailwindcss", function()
+      if not tailwindcss.settings.disable_lsp then
+        langs_utils.use_lsp_mason(tailwindcss.settings.language_server_name)
       end
 
-      if not typescript.settings.disable_treesitter then
-        langs_utils.use_tree_sitter(typescript.settings.treesitter_grammars)
+      if not tailwindcss.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(tailwindcss.settings.treesitter_grammars)
       end
 
-      if not typescript.settings.disable_formatting then
+      if not tailwindcss.settings.disable_formatting and tailwindcss.settings.formatting_package then
         langs_utils.use_null_ls(
-          typescript.settings.formatting_package,
-          typescript.settings.formatting_provider,
-          typescript.settings.formatting_config
+          tailwindcss.settings.formatting_package,
+          tailwindcss.settings.formatting_provider,
+          tailwindcss.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }
 
-return typescript
+return tailwindcss

--- a/lua/doom/modules/langs/terraform/init.lua
+++ b/lua/doom/modules/langs/terraform/init.lua
@@ -29,13 +29,12 @@ terraform.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 terraform.autocmds = {
   {
     "BufWinEnter",
     "*.hcl,*.tf,*.tfvars,*.nomad",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("terraform", function()
       if not terraform.settings.disable_lsp then
         langs_utils.use_lsp_mason(terraform.settings.language_server_name)
       end
@@ -51,7 +50,7 @@ terraform.autocmds = {
           terraform.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/toml/init.lua
+++ b/lua/doom/modules/langs/toml/init.lua
@@ -1,54 +1,54 @@
-local terraform = {}
+local typescript = {}
 
-terraform.settings = {
+typescript.settings = {
   --- Disables auto installing the treesitter
   --- @type boolean
   disable_treesitter = false,
   --- Treesitter grammars to install
   --- @type string|string[]
-  treesitter_grammars = "hcl",
+  treesitter_grammars = "toml",
 
   --- Disables default LSP config
   --- @type boolean
   disable_lsp = false,
   --- Name of the language server
   --- @type string
-  language_server_name = "terraformls",
+  language_server_name = "taplo",
 
   --- Disables null-ls formatting sources
   --- @type boolean
   disable_formatting = false,
   --- Mason.nvim package to auto install the formatter from
-  --- @type nil
-  formatting_package = nil,
+  --- @type string
+  formatting_package = "taplo",
   --- String to access the null_ls diagnositcs provider
   --- @type string
-  formatting_provider = "builtins.formatting.terraform_fmt",
+  formatting_provider = "builtins.formatting.taplo",
   --- Function to configure null-ls formatter
   --- @type function|nil
   formatting_config = nil,
 }
 
-terraform.autocmds = {
+typescript.autocmds = {
   {
-    "BufWinEnter",
-    "*.hcl,*.tf,*.tfvars,*.nomad",
+    "FileType",
+    "toml",
     function()
       local langs_utils = require("doom.modules.langs.utils")
 
-      if not terraform.settings.disable_lsp then
-        langs_utils.use_lsp_mason(terraform.settings.language_server_name)
+      -- if not typescript.settings.disable_lsp then
+      --   langs_utils.use_lsp_mason(typescript.settings.language_server_name)
+      -- end
+
+      if not typescript.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(typescript.settings.treesitter_grammars)
       end
 
-      if not terraform.settings.disable_treesitter then
-        langs_utils.use_tree_sitter(terraform.treesitter_grammars)
-      end
-
-      if not terraform.settings.disable_formatting then
+      if not typescript.settings.disable_formatting then
         langs_utils.use_null_ls(
-          terraform.settings.diagnostics_package,
-          terraform.settings.formatting_provider,
-          terraform.settings.formatting_config
+          typescript.settings.formatting_package,
+          typescript.settings.formatting_provider,
+          typescript.settings.formatting_config
         )
       end
     end,
@@ -56,4 +56,4 @@ terraform.autocmds = {
   },
 }
 
-return terraform
+return typescript

--- a/lua/doom/modules/langs/toml/init.lua
+++ b/lua/doom/modules/langs/toml/init.lua
@@ -29,16 +29,15 @@ typescript.settings = {
   formatting_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 typescript.autocmds = {
   {
     "FileType",
     "toml",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
-      -- if not typescript.settings.disable_lsp then
-      --   langs_utils.use_lsp_mason(typescript.settings.language_server_name)
-      -- end
+    langs_utils.wrap_language_setup("toml", function()
+      if not typescript.settings.disable_lsp then
+        langs_utils.use_lsp_mason(typescript.settings.language_server_name)
+      end
 
       if not typescript.settings.disable_treesitter then
         langs_utils.use_tree_sitter(typescript.settings.treesitter_grammars)
@@ -51,7 +50,7 @@ typescript.autocmds = {
           typescript.settings.formatting_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/typescript/init.lua
+++ b/lua/doom/modules/langs/typescript/init.lua
@@ -1,33 +1,97 @@
-local utils = require("doom.utils")
-
 local typescript = {}
 
-typescript.settings = {}
+typescript.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "typescript",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "tsserver",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.eslint_d",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.eslint_d",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_code_actions = false,
+  --- Mason.nvim package to auto install the code_actions provider from
+  --- @type string
+  code_actions_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  code_actions_provider = "builtins.code_actions.eslint_d",
+  --- Function to configure null-ls code_actions
+  --- @type function|nil
+  code_actions_config = nil,
+}
 
 typescript.autocmds = {
   {
-    "BufWinEnter",
-    "*.js,*.jsx,*.ts,*.tsx",
-    utils.make_run_once_function(function()
+    "FileType",
+    "javascript,typescript,javascriptreact,typescriptreact",
+    function()
       local langs_utils = require("doom.modules.langs.utils")
-      langs_utils.use_lsp("tsserver")
 
-      vim.defer_fn(function()
-        local ts_install = require("nvim-treesitter.install")
-        ts_install.ensure_installed("typescript", "javascript", "tsx")
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.eslint_d,
-          null_ls.builtins.code_actions.eslint_d,
-          null_ls.builtins.diagnostics.eslint_d,
-        })
+      if not typescript.settings.disable_lsp then
+        langs_utils.use_lsp_mason(typescript.settings.language_server_name)
       end
-    end),
+
+      if not typescript.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(typescript.settings.treesitter_grammars)
+      end
+
+      if not typescript.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          typescript.settings.formatting_package,
+          typescript.settings.formatting_provider,
+          typescript.settings.formatting_config
+        )
+      end
+      if not typescript.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          typescript.settings.diagnostics_package,
+          typescript.settings.diagnostics_provider,
+          typescript.settings.diagnostics_config
+        )
+      end
+      if not typescript.settings.disable_code_actions then
+        langs_utils.use_null_ls(
+          typescript.settings.code_actions_package,
+          typescript.settings.code_actions_provider,
+          typescript.settings.code_actions_config
+        )
+      end
+    end,
     once = true,
   },
 }

--- a/lua/doom/modules/langs/typescript/init.lua
+++ b/lua/doom/modules/langs/typescript/init.lua
@@ -55,13 +55,12 @@ typescript.settings = {
   code_actions_config = nil,
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 typescript.autocmds = {
   {
-    "FileType",
-    "javascript,typescript,javascriptreact,typescriptreact",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    "BufWinEnter",
+    "*.js,*.mjs,*.jsx,*.ts,*tsx",
+    langs_utils.wrap_language_setup("typescript/javascript", function()
       if not typescript.settings.disable_lsp then
         langs_utils.use_lsp_mason(typescript.settings.language_server_name)
       end
@@ -91,7 +90,7 @@ typescript.autocmds = {
           typescript.settings.code_actions_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/utils.lua
+++ b/lua/doom/modules/langs/utils.lua
@@ -58,7 +58,6 @@ module.use_null_ls = function(package_name, null_ls_path, configure_function)
           .. ".  null_ls_path should have 3 segments i.e. `builtins.formatting.stylua"
       )
     end
-    print(vim.inspect(path))
     local provider = null_ls[path[1]][path[2]][path[3]]
 
     if configure_function then

--- a/lua/doom/modules/langs/utils.lua
+++ b/lua/doom/modules/langs/utils.lua
@@ -85,7 +85,6 @@ end
 ---@param package_name string Name of the package that's being installed
 ---@param err_message string Reason for erroring out of installing mason package
 local default_error_handler = function(package_name, err_message)
-  require("doom.utils.logging")
   error(("Error installing mason package `%s`.  Reason: %s "):format(package_name, err_message))
 end
 
@@ -291,7 +290,7 @@ module.wrap_language_setup = function(module_name, setup_fn)
   local setup_language = function()
     local ok, error = xpcall(setup_fn, debug.traceback)
     if not ok then
-      log.error(("Error setting up language %s. \n%s"):format(module_name, error))
+      log.error(("Error setting up language `%s`. \n%s"):format(module_name, error))
     end
   end
   return setup_language

--- a/lua/doom/modules/langs/utils.lua
+++ b/lua/doom/modules/langs/utils.lua
@@ -48,28 +48,30 @@ end
 --- end)
 --- ```
 module.use_null_ls = function(package_name, null_ls_path, configure_function)
-  local start_null_ls = function()
-    local null_ls = require("null-ls")
-    local path = vim.split(null_ls_path, "%.")
-    if #path ~= 3 then
-      log.error(
-        "Error setting up null-ls provider "
-          .. null_ls_path
-          .. ".  null_ls_path should have 3 segments i.e. `builtins.formatting.stylua"
-      )
-    end
-    local provider = null_ls[path[1]][path[2]][path[3]]
-
-    if configure_function then
-      provider = configure_function(provider)
-    end
-
-    module.use_null_ls_source({ provider })
-  end
-
-  -- Auto install package if necessary
   if doom.features.linter then
-    if doom.features.auto_installer and package_name ~= nil then
+    -- Check if null-ls is loaded and load it if not.
+    local ok = pcall(require, "null-ls")
+    if not ok then
+      vim.cmd("packadd null-ls.nvim")
+    end
+
+    local start_null_ls = function()
+      local null_ls = require("null-ls")
+      local path = vim.split(null_ls_path, "%.", nil)
+      if #path ~= 3 then
+        log.error(("Error setting up null-ls provider `%s`.\n\n  null_ls_path should have 3 segments i.e. `builtins.formatting.stylua"):format(null_ls_path))
+      end
+      local provider = null_ls[path[1]][path[2]][path[3]]
+
+      if configure_function then
+        provider = configure_function(provider)
+      end
+
+      module.use_null_ls_source({ provider })
+    end
+
+    -- If auto_install module is enabled, try to install package before starting
+    if doom.features.auto_install and package_name ~= nil then
       module.use_mason_package(package_name, start_null_ls)
     else
       vim.defer_fn(function()
@@ -80,33 +82,67 @@ module.use_null_ls = function(package_name, null_ls_path, configure_function)
 end
 
 --- Default error handler for use_mason_package utility function
+---@param package_name string Name of the package that's being installed
 ---@param err_message string Reason for erroring out of installing mason package
-local default_error_handler = function(err_message)
+local default_error_handler = function(package_name, err_message)
   require("doom.utils.logging")
-  log.error("use_mason_package error: " .. vim.inspect(err_message))
+  error(("Error installing mason package `%s`.  Reason: %s "):format(package_name, err_message))
 end
 
 --- Installs a mason package and provides an on-ready handler
----@param package_name string
+---@param package_name string|nil Name of mason.nvim package to install
 ---@param success_handler function
 ---@param error_handler function|nil
 module.use_mason_package = function(package_name, success_handler, error_handler)
   local mason = require("mason-registry")
   local on_err = error_handler or default_error_handler
-  local ok, err = pcall(function()
+  if package_name == nil then
+    on_err("nil", "No package_name provided.")
+    return
+  end
+  local ok, err = xpcall(function()
     local package = mason.get_package(package_name)
     if not package:is_installed() then
+      -- If statusline enabled, push the package to the statusline state
+      -- So we can provide feedback to user
+      local statusline = doom.features.statusline
+      if statusline then
+        statusline.state.start_mason_package(package_name)
+      end
+
       package:install()
-      package:on("install:success", success_handler)
-      package:on("install:failed", function()
-        on_err("Error installing mason package.")
+      package:on("install:success", function(handle)
+        -- Remove package from statusline state to hide it
+        if statusline then
+          statusline.state.finish_mason_package(package_name)
+        end
+        vim.schedule(function()
+          success_handler(handle)
+        end)
+      end)
+      package:on("install:failed", function(pkg)
+        -- Remove package from statusline state to hide it
+        if statusline then
+          statusline.state.finish_mason_package(package_name)
+        end
+        local err = "Mason.nvim failed safely.  You might be missing the dependencies to install this package."
+        if (pkg and pkg.stdio and pkg.stdio.buffers and pkg.stdio.buffers.stderr) then
+          err = err .. "\n \n"
+          for _, line in ipairs(pkg.stdio.buffers.stderr) do
+            err = err .. line
+          end
+        end
+
+        vim.schedule(function()
+          on_err(package_name, err)
+        end)
       end)
     else
       success_handler(package, package.get_handle(package))
     end
-  end)
+  end, debug.traceback)
   if not ok then
-    on_err(err)
+    on_err(package_name, "There was an unknown error when trying to install. \n\n" .. err)
   end
 end
 
@@ -177,28 +213,32 @@ module.use_lsp_mason = function(lsp_name, options)
 
   -- Auto install if possible
   if utils.is_module_enabled("features", "auto_install") and not opts.no_installer then
-    local mason = require("mason-registry")
     local lspconfig_to_package = require("mason-lspconfig.mappings.server").lspconfig_to_package
-    local ok = pcall(function()
-      local package = mason.get_package(lspconfig_to_package[lsp_name])
-      if not package:is_installed() then
-        vim.defer_fn(function()
-          package:install()
-        end, 50)
-        package:on("install:success", function()
-          start_lsp()
-        end)
-      else
-        start_lsp()
-      end
-    end)
-    if not ok then
-      start_lsp()
-    end
+    module.use_mason_package(lspconfig_to_package[lsp_name], start_lsp)
   else
     start_lsp()
   end
 end
+
+-- module.use_dap = function(config_name, settings)
+--   local utils = require("doom.utils")
+--   if utils.is_module_enabled("features", "dap") then
+--     vim.defer_fn(function()
+--       local dap = require("dap")
+--       dap.configurations.python = {
+--         {
+--           type = "python",
+--           request = "launch",
+--           name = "Launch file",
+--           program = "${file}",
+--           pythonPath = function()
+--             return "/usr/bin/python"
+--           end,
+--         },
+--       }
+--     end)
+--   end
+-- end
 
 --- Helper to attach illuminate on LSP
 module.illuminate_attach = function(client)
@@ -241,6 +281,20 @@ module.get_capabilities = function()
   }
 
   return capabilities
+end
+
+--- Helper to wrap language setup functions with error handling + avoid raceconditions
+---@param module_name string Name of module for error logging
+---@param setup_fn function Function that sets up this language
+---@return function Wrapped setup function
+module.wrap_language_setup = function(module_name, setup_fn)
+  local setup_language = function()
+    local ok, error = xpcall(setup_fn, debug.traceback)
+    if not ok then
+      log.error(("Error setting up language %s. \n%s"):format(module_name, error))
+    end
+  end
+  return setup_language
 end
 
 return module

--- a/lua/doom/modules/langs/vue/init.lua
+++ b/lua/doom/modules/langs/vue/init.lua
@@ -13,7 +13,7 @@ vue.settings = {
     "html",
     "scss",
     "javascript",
-    "typescript"
+    "typescript",
   },
 
   --- Disables default LSP config
@@ -131,17 +131,15 @@ vue.settings = {
   },
 }
 
+local langs_utils = require("doom.modules.langs.utils")
 vue.autocmds = {
   {
     "FileType",
-    "javascript,vue,javascriptreact,typescriptreact",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    "vue",
+    langs_utils.wrap_language_setup("vue", function()
       if not vue.settings.disable_lsp then
         local lspconfig_util = require("lspconfig/util")
         langs_utils.use_lsp_mason(vue.settings.language_server_name)
-
 
         local function get_typescript_server_path(root_dir)
           -- Alternative location if installed as root:
@@ -168,9 +166,10 @@ vue.autocmds = {
 
         -- volar needs works with typescript server, needs to get the typescript server from the project's node_modules
         local function on_new_config(new_config, new_root_dir)
-          if new_config.init_options
-              and new_config.init_options.typescript
-              and new_config.init_options.typescript.serverPath == ""
+          if
+            new_config.init_options
+            and new_config.init_options.typescript
+            and new_config.init_options.typescript.serverPath == ""
           then
             new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
           end
@@ -194,21 +193,21 @@ vue.autocmds = {
         }
 
         local volar_api_config =
-        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_api, base_config)
+          vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_api, base_config)
         langs_utils.use_lsp("volar", {
           name = "volar_api",
           config = volar_api_config,
         })
 
         local volar_doc_config =
-        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_doc, base_config)
+          vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_doc, base_config)
         langs_utils.use_lsp("volar", {
           name = "volar_doc",
           config = volar_doc_config,
         })
 
         local volar_html_config =
-        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_html, base_config)
+          vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_html, base_config)
         langs_utils.use_lsp("volar", {
           name = "volar_html",
           config = volar_html_config,
@@ -240,7 +239,7 @@ vue.autocmds = {
           vue.settings.code_actions_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/modules/langs/vue/init.lua
+++ b/lua/doom/modules/langs/vue/init.lua
@@ -1,6 +1,67 @@
 local vue = {}
 
 vue.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = {
+    "vue",
+    "css",
+    "scss",
+    "html",
+    "scss",
+    "javascript",
+    "typescript"
+  },
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "tsserver",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.eslint_d",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.eslint_d",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_code_actions = false,
+  --- Mason.nvim package to auto install the code_actions provider from
+  --- @type string
+  code_actions_package = "eslint_d",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  code_actions_provider = "builtins.code_actions.eslint_d",
+  --- Function to configure null-ls code_actions
+  --- @type function|nil
+  code_actions_config = nil,
+
   -- Volar API lspconfig options
   volar_api = {
     default_config = {
@@ -34,7 +95,7 @@ vue.settings = {
     default_config = {
       filetypes = { "vue" },
       -- If you want to use Volar's Take Over Mode (if you know, you know):
-      --filetypes = { 'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue', 'json' },
+      --filetypes = { 'vue', 'javascript', 'javascriptreact', 'typescriptreact', 'vue', 'json' },
       init_options = {
         languageFeatures = {
           documentHighlight = true,
@@ -52,7 +113,7 @@ vue.settings = {
     default_config = {
       filetypes = { "vue" },
       -- If you want to use Volar's Take Over Mode (if you know, you know), intentionally no 'json':
-      --filetypes = { 'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue' },
+      --filetypes = { 'vue', 'javascript', 'javascriptreact', 'typescriptreact', 'vue' },
       init_options = {
         documentFeatures = {
           selectionRange = true,
@@ -70,107 +131,114 @@ vue.settings = {
   },
 }
 
-vue.configs = {}
-
 vue.autocmds = {
   {
-    "BufWinEnter",
-    "*.vue",
+    "FileType",
+    "javascript,vue,javascriptreact,typescriptreact",
     function()
-      local lspconfig_util = require("lspconfig/util")
       local langs_utils = require("doom.modules.langs.utils")
 
-      local function get_typescript_server_path(root_dir)
-        -- Alternative location if installed as root:
-        -- local global_ts = '/usr/local/lib/node_modules/typescript/lib/tsserverlibrary.js'
-        local found_ts = ""
-        local function check_dir(path)
-          found_ts = lspconfig_util.path.join(
-            path,
-            "node_modules",
-            "typescript",
-            "lib",
-            "tsserverlibrary.js"
-          )
-          if lspconfig_util.path.exists(found_ts) then
-            return path
+      if not vue.settings.disable_lsp then
+        local lspconfig_util = require("lspconfig/util")
+        langs_utils.use_lsp_mason(vue.settings.language_server_name)
+
+
+        local function get_typescript_server_path(root_dir)
+          -- Alternative location if installed as root:
+          -- local global_ts = '/usr/local/lib/node_modules/typescript/lib/tsserverlibrary.js'
+          local found_ts = ""
+          local function check_dir(path)
+            found_ts = lspconfig_util.path.join(
+              path,
+              "node_modules",
+              "typescript",
+              "lib",
+              "tsserverlibrary.js"
+            )
+            if lspconfig_util.path.exists(found_ts) then
+              return path
+            end
+          end
+
+          if lspconfig_util.search_ancestors(root_dir, check_dir) then
+            return found_ts
+          end
+          return ""
+        end
+
+        -- volar needs works with typescript server, needs to get the typescript server from the project's node_modules
+        local function on_new_config(new_config, new_root_dir)
+          if new_config.init_options
+              and new_config.init_options.typescript
+              and new_config.init_options.typescript.serverPath == ""
+          then
+            new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
           end
         end
-        if lspconfig_util.search_ancestors(root_dir, check_dir) then
-          return found_ts
-        end
-        return ""
-      end
-      -- volar needs works with typescript server, needs to get the typescript server from the project's node_modules
-      local function on_new_config(new_config, new_root_dir)
-        if
-          new_config.init_options
-          and new_config.init_options.typescript
-          and new_config.init_options.typescript.serverPath == ""
-        then
-          new_config.init_options.typescript.serverPath = get_typescript_server_path(new_root_dir)
-        end
-      end
-      local volar_root_dir = lspconfig_util.root_pattern("package.json")
 
-      -- Contains base configuration necessary for volar to start
-      local base_config = {
-        default_config = {
-          cmd = { "vue-language-server", "--stdio" },
-          -- cmd = volar.document_config.default_config.cmd,
-          root_dir = volar_root_dir,
-          on_new_config = on_new_config,
-          init_options = {
-            typescript = {
-              serverPath = "",
+        local volar_root_dir = lspconfig_util.root_pattern("package.json")
+
+        -- Contains base configuration necessary for volar to start
+        local base_config = {
+          default_config = {
+            cmd = { "vue-language-server", "--stdio" },
+            -- cmd = volar.document_config.default_config.cmd,
+            root_dir = volar_root_dir,
+            on_new_config = on_new_config,
+            init_options = {
+              typescript = {
+                serverPath = "",
+              },
             },
           },
-        },
-      }
+        }
 
-      local volar_api_config =
+        local volar_api_config =
         vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_api, base_config)
-      langs_utils.use_lsp("volar", {
-        name = "volar_api",
-        config = volar_api_config,
-      })
-
-      local volar_doc_config =
-        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_doc, base_config)
-      langs_utils.use_lsp("volar", {
-        name = "volar_doc",
-        config = volar_doc_config,
-      })
-
-      local volar_html_config =
-        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_html, base_config)
-      langs_utils.use_lsp("volar", {
-        name = "volar_html",
-        config = volar_html_config,
-      })
-
-      vim.defer_fn(function()
-        local ts_install = require("nvim-treesitter.install")
-        ts_install.ensure_installed(
-          "vue",
-          "css",
-          "scss",
-          "html",
-          "scss",
-          "javascript",
-          "typescript"
-        )
-      end, 0)
-
-      -- Setup null-ls
-      if doom.features.linter then
-        local null_ls = require("null-ls")
-
-        langs_utils.use_null_ls_source({
-          null_ls.builtins.formatting.eslint_d,
-          null_ls.builtins.code_actions.eslint_d,
-          null_ls.builtins.diagnostics.eslint_d,
+        langs_utils.use_lsp("volar", {
+          name = "volar_api",
+          config = volar_api_config,
         })
+
+        local volar_doc_config =
+        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_doc, base_config)
+        langs_utils.use_lsp("volar", {
+          name = "volar_doc",
+          config = volar_doc_config,
+        })
+
+        local volar_html_config =
+        vim.tbl_deep_extend("force", {}, doom.langs.vue.settings.volar_html, base_config)
+        langs_utils.use_lsp("volar", {
+          name = "volar_html",
+          config = volar_html_config,
+        })
+      end
+
+      if not vue.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(vue.settings.treesitter_grammars)
+      end
+
+      if not vue.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          vue.settings.formatting_package,
+          vue.settings.formatting_provider,
+          vue.settings.formatting_config
+        )
+      end
+      if not vue.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          vue.settings.diagnostics_package,
+          vue.settings.diagnostics_provider,
+          vue.settings.diagnostics_config
+        )
+      end
+      if not vue.settings.disable_code_actions then
+        langs_utils.use_null_ls(
+          vue.settings.code_actions_package,
+          vue.settings.code_actions_provider,
+          vue.settings.code_actions_config
+        )
       end
     end,
     once = true,

--- a/lua/doom/modules/langs/yaml/init.lua
+++ b/lua/doom/modules/langs/yaml/init.lua
@@ -1,0 +1,95 @@
+local yaml = {}
+
+yaml.settings = {
+  --- Disables auto installing the treesitter
+  --- @type boolean
+  disable_treesitter = false,
+  --- Treesitter grammars to install
+  --- @type string|string[]
+  treesitter_grammars = "yaml",
+
+  --- Disables default LSP config
+  --- @type boolean
+  disable_lsp = false,
+  --- Name of the language server
+  --- @type string
+  language_server_name = "tsserver",
+
+  --- Disables null-ls formatting sources
+  --- @type boolean
+  disable_formatting = false,
+  --- Mason.nvim package to auto install the formatter from
+  --- @type string
+  formatting_package = "yamlfmt",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  formatting_provider = "builtins.formatting.yamlfmt",
+  --- Function to configure null-ls formatter
+  --- @type function|nil
+  formatting_config = nil,
+
+  --- Disables null-ls diagnostic sources
+  --- @type boolean
+  disable_diagnostics = false,
+  --- Mason.nvim package to auto install the diagnostics provider from
+  --- @type string
+  diagnostics_package = "yamllint",
+  --- String to access the null_ls diagnositcs provider
+  --- @type string
+  diagnostics_provider = "builtins.diagnostics.yamllint",
+  --- Function to configure null-ls diagnostics
+  --- @type function|nil
+  diagnostics_config = nil,
+}
+
+yaml.packages = {
+  ["SchemaStore.nvim"] = {
+    "b0o/SchemaStore.nvim",
+    commit = "f55842dc797faad8cf7b0d9ce75c59da654aa018",
+    ft = { "yaml" },
+  },
+}
+
+yaml.autocmds = {
+  {
+    "FileType",
+    "yaml",
+    function()
+      local langs_utils = require("doom.modules.langs.utils")
+
+      if not yaml.settings.disable_lsp then
+        langs_utils.use_lsp_mason(yaml.settings.language_server_name, {
+          config = {
+            settings = {
+              yaml = {
+                schemas = require("schemastore").yaml.schemas()
+              }
+            }
+          }
+        })
+      end
+
+      if not yaml.settings.disable_treesitter then
+        langs_utils.use_tree_sitter(yaml.settings.treesitter_grammars)
+      end
+
+      if not yaml.settings.disable_formatting then
+        langs_utils.use_null_ls(
+          yaml.settings.formatting_package,
+          yaml.settings.formatting_provider,
+          yaml.settings.formatting_config
+        )
+      end
+      if not yaml.settings.disable_diagnostics then
+        langs_utils.use_null_ls(
+          yaml.settings.diagnostics_package,
+          yaml.settings.diagnostics_provider,
+          yaml.settings.diagnostics_config
+        )
+      end
+    end,
+    once = true,
+  },
+}
+
+return yaml

--- a/lua/doom/modules/langs/yaml/init.lua
+++ b/lua/doom/modules/langs/yaml/init.lua
@@ -42,31 +42,14 @@ yaml.settings = {
   diagnostics_config = nil,
 }
 
-yaml.packages = {
-  ["SchemaStore.nvim"] = {
-    "b0o/SchemaStore.nvim",
-    commit = "f55842dc797faad8cf7b0d9ce75c59da654aa018",
-    ft = { "yaml" },
-  },
-}
-
+local langs_utils = require("doom.modules.langs.utils")
 yaml.autocmds = {
   {
     "FileType",
     "yaml",
-    function()
-      local langs_utils = require("doom.modules.langs.utils")
-
+    langs_utils.wrap_language_setup("yaml", function()
       if not yaml.settings.disable_lsp then
-        langs_utils.use_lsp_mason(yaml.settings.language_server_name, {
-          config = {
-            settings = {
-              yaml = {
-                schemas = require("schemastore").yaml.schemas()
-              }
-            }
-          }
-        })
+        langs_utils.use_lsp_mason(yaml.settings.language_server_name)
       end
 
       if not yaml.settings.disable_treesitter then
@@ -87,7 +70,7 @@ yaml.autocmds = {
           yaml.settings.diagnostics_config
         )
       end
-    end,
+    end),
     once = true,
   },
 }

--- a/lua/doom/utils/logging.lua
+++ b/lua/doom/utils/logging.lua
@@ -73,18 +73,8 @@ log.new = function(config, standalone)
     local console_string =
       string.format("[%-6s%s] %s: %s", nameupper, os.date("%H:%M:%S"), console_lineinfo, msg)
 
-    if config.highlights and level_config.hl then
-      vim.cmd(string.format("echohl %s", level_config.hl))
-    end
-
-    local split_console = vim.split(console_string, "\n")
-    for _, v in ipairs(split_console) do
-      vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, vim.fn.escape(v, '"')))
-    end
-
-    if config.highlights and level_config.hl then
-      vim.cmd("echohl NONE")
-    end
+    local message = {("[%s] %s"):format(config.plugin, console_string), level_config.hl}
+    vim.api.nvim_echo({ message }, true, {})
   end)
 
   local log_at_level = function(level, level_config, message_maker, ...)

--- a/modules.lua
+++ b/modules.lua
@@ -64,6 +64,7 @@ return {
     -- "gdscript",
     -- "gdscript",
     -- "php",
+    -- "ruby",
 
     -- Web
     -- "javascript",
@@ -71,11 +72,13 @@ return {
     -- "css",
     -- "vue",
     -- "tailwindcss",
+    -- "svelte",
 
     -- Compiled
     -- "rust",
     -- "cc",
     -- "ocaml",
+    -- "haskell",
 
     -- JIT
     -- "c_sharp",

--- a/modules.lua
+++ b/modules.lua
@@ -82,7 +82,9 @@ return {
     -- "kotlin",
     -- "java",
 
-    -- "config",          -- JSON, YAML, TOML
+    -- "json",
+    -- "yaml",
+    -- "toml",
     -- "markdown",
     -- "terraform",       -- Terraform / hcl files support
     -- "dockerfile",


### PR DESCRIPTION
Big changes:
- This PR switches from nvim-lsp-installer -> mason.nvim.
- Adds a standardised set of options to modify and configure the null-ls/lsp sources of modules without overriding it.
- Fixed and improved formatting of the logging service.
- Added a new element to the statusline that indicates when a package is being installed.  This element can be clicked to bring up the `:Mason` menu.
  - <img width="824" alt="Screen Shot 2022-10-12 at 9 07 47 pm" src="https://user-images.githubusercontent.com/7402063/195315046-2d3452cb-8ac1-4265-a4ce-82a43b07c4c6.png">
- Seperates the `config` language module into `json`, `yaml`, `toml` modules.
- Tested and fixed all language startup issues to the best of my ability.


Extra minor changes to statusline: 
- Made statusline always show filetype.
- Split LSP indicator into it's own statusline element + made it clickable.

Most of the extra LOC are boilerplate to allow users to configure the LSP/Null-ls sources.