### PR TITLE
doom: disable slow features on large files

### DIFF
--- a/lua/doom/modules/core/treesitter/init.lua
+++ b/lua/doom/modules/core/treesitter/init.lua
@@ -68,13 +68,15 @@ treesitter.packages = {
 treesitter.configs = {}
 treesitter.configs["nvim-treesitter"] = function()
   local is_module_enabled = require("doom.utils").is_module_enabled
-  require("nvim-treesitter.configs").setup(
-    vim.tbl_deep_extend("force", doom.core.treesitter.settings.treesitter, {
-      autopairs = {
-        enable = is_module_enabled("features", "autopairs"),
-      },
-    })
-  )
+  local settings = vim.tbl_deep_extend("force", doom.core.treesitter.settings.treesitter, {
+    autopairs = {
+      enable = is_module_enabled("features", "autopairs"),
+    },
+  })
+  if is_module_enabled("features", "largefile") then
+    settings = require("doom.modules.features.largefile").update_treesitter(settings)
+  end
+  require("nvim-treesitter.configs").setup(settings)
 
   --  Check if user is using clang and notify that it has poor compatibility with treesitter
   --  WARN: 19/11/2021 | issues: #222, #246 clang compatibility could improve in future

--- a/lua/doom/modules/features/gitsigns/init.lua
+++ b/lua/doom/modules/features/gitsigns/init.lua
@@ -81,7 +81,12 @@ gitsigns.packages = {
 
 gitsigns.configs = {}
 gitsigns.configs["gitsigns.nvim"] = function()
-  require("gitsigns").setup(doom.features.gitsigns.settings)
+  local settings = doom.features.gitsigns.settings
+  local is_module_enabled = require("doom.utils").is_module_enabled
+  if is_module_enabled("features", "largefile") then
+    settings.max_file_length = doom.features.largefile.settings.max_line_count
+  end
+  require("gitsigns").setup(settings)
 end
 
 return gitsigns

--- a/lua/doom/modules/features/illuminate/init.lua
+++ b/lua/doom/modules/features/illuminate/init.lua
@@ -20,9 +20,16 @@ illuminate.packages = {
   },
 }
 
+
 illuminate.configs = {}
 illuminate.configs["vim-illuminate"] = function()
+  local is_module_enabled = require("doom.utils").is_module_enabled
   vim.g.Illuminate_ftblacklist = doom.features.illuminate.settings.blacklist
+  if is_module_enabled("features", "largefile") then
+    require('illuminate').configure({
+      large_file_cutoff = doom.features.largefile.settings.max_line_count
+    })
+  end
 end
 
 return illuminate

--- a/lua/doom/modules/features/largefile/init.lua
+++ b/lua/doom/modules/features/largefile/init.lua
@@ -1,0 +1,48 @@
+local largefile = {}
+
+largefile.settings = {
+  max_line_count = 10000,
+}
+
+largefile.packages = {
+  ["LargeFile"] = {
+    "vim-scripts/LargeFile",
+    commit = "3941a37b2b0288524300348a39521a46539bf9f6",
+    setup = function()
+      vim.g.LargeFile = 1 -- 1 MiB
+    end,
+  },
+}
+
+largefile.should_disable = function(_lang, bufnr)
+  -- need to check file size too:
+  -- on initial open the buffer would be unloaded and report line count as 0
+  -- and we'd trigger an initial parsing of the large file which could be
+  -- a delay of seconds
+  local fname = vim.api.nvim_buf_get_name(bufnr)
+  if string.len(fname) > 0 then
+    local fsize = vim.fn.getfsize(fname)
+    if fsize > vim.g.LargeFile * 1024 * 1024 then
+      -- flag for debugging
+      vim.b.LargeFile_treesitter_mode_fsize = true
+      return true
+    end
+  end
+  if vim.api.nvim_buf_line_count(bufnr) > doom.features.largefile.settings.max_line_count then
+    -- flag for debugging
+    vim.b.LargeFile_treesitter_mode_linecount = true
+    return true
+  end
+  return false
+end
+
+largefile.update_treesitter = function(settings)
+  for _, feature in pairs(settings) do
+    -- keep enable as is, but add a function that runs on buffer open
+    -- to determine whether to disable the feature for that buffer
+    feature.disable = largefile.should_disable
+  end
+  return settings
+end
+
+return largefile

--- a/lua/doom/modules/features/lsp/init.lua
+++ b/lua/doom/modules/features/lsp/init.lua
@@ -211,14 +211,6 @@ lsp.configs["nvim-cmp"] = function()
 
   local replace_termcodes = utils.replace_termcodes
 
-  local source_map = {
-    nvim_lsp = "[LSP]",
-    luasnip = "[Snp]",
-    buffer = "[Buf]",
-    nvim_lua = "[Lua]",
-    path = "[Path]",
-  }
-
   --- Helper function to check what <Tab> behaviour to use
   --- @return boolean
   local function check_backspace()

--- a/lua/doom/modules/langs/cc/init.lua
+++ b/lua/doom/modules/langs/cc/init.lua
@@ -1,5 +1,3 @@
-local utils = require("doom.utils")
-
 local cc = {}
 
 cc.settings = {

--- a/modules.lua
+++ b/modules.lua
@@ -26,6 +26,7 @@ return {
     "indentlines", -- Show indent lines with special characters
     "range_highlight", -- Highlight selected range from commands
     "todo_comments", -- Highlight TODO: comments
+    "largefile", -- Disable treesitter and various other slow features on large files
     -- "doom_themes",     -- Extra themes for doom
 
     -- UI Components


### PR DESCRIPTION
I regularly have to open files that are gigabytes in size (logfiles), or source code that contains hundreds of thousands of lines, in which case Neovim can hang for a long time on opening the file, and every action inside the file is very very slow (moving lines takes several seconds).

Some of the features which become very slow on large files include:
* gitsigns
* illuminate
* the various treesitter plugins (and treesitter itself). I think this is because it needs to parse the file from the very beginning in order to highlight correctly, and that can take a long time. The fallback (default) highlighting in Neovim that uses regular expressions may be slower and imprecise in general, but at least it works with more reasonable speed on large files.
* various other Vim features that the existing LargeFile plugin already disables

Since Doom-nvim is focused on performance I think it'd be appropriate to have a feature to deal with large files better.
It won't be pretty, but at least the file will open and you can edit it.

If I have time I can take a look at more gradual disabling of features (e.g. maybe treesitter highlighting itself is not too bad, it is just all the tree-sitter plugins that are very slow on large files), but meanwhile this might be useful for someone already.

I also have some scripts that can measure performance using `hyperfine` and some simple scenarios (e.g. fabricate a "large" file with thousands of lines and measure how long it takes to use a motion to go to the end and insert some characters). These scenarios are more than just the usual "vim startup time", which although important may miss the point in some cases: I think what matters is "time to first action" (similarly to how browser latency is sometimes measured as 'time to first byte'): if my editor is frozen for minutes and won't respond to anything I type when I open a file, then the fact that the editor  "started up" in 10ms or 100ms matters little, what should be measured is how soon before the editor is able to receive user input. (And then all else being equal, a faster startup "display" time is of course desirable).

The scripts aren't quite finished yet, so they are not included in this PR.  You can see their current state at https://github.com/edwintorok/doom-nvim/blob/main/tools/profileit.sh and https://github.com/edwintorok/doom-nvim/blob/main/tools/compare_perf.sh. 
It is a bit tricky to automate bootstrapping of neovim from 2 different commits to compare performance in a reproducible way, and I don't currently have a way to automatically check whether bootstrapping of doom succeeded or not, if it hasn't then it'll print various warnings/errors and not initialize completely which will cause any performance comparisons to be invalid.

What do you think? 