### PR TITLE
refactor(tools/install.sh): remove `declare` bashisms, set to executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Some of the defining features that make this project unique are:
 ### Mac OS / Linux
 
 ```bash
-curl -s https://raw.githubusercontent.com/doom-neovim/doom-nvim/main/tools/install.sh | sh
+curl -s https://raw.githubusercontent.com/doom-neovim/doom-nvim/main/tools/install.sh && ./install.sh
 ```
 
 ### Manual (Mac OS / Linux)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-declare -r XDG_DATA_HOME="${XDG_DATA_HOME:-"$HOME/.local/share"}"
-declare -r XDG_CACHE_HOME="${XDG_CACHE_HOME:-"$HOME/.cache"}"
-declare -r XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-"$HOME/.config"}"
+typeset -r XDG_DATA_HOME="${XDG_DATA_HOME:-"$HOME/.local/share"}"
+typeset -r XDG_CACHE_HOME="${XDG_CACHE_HOME:-"$HOME/.cache"}"
+typeset -r XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-"$HOME/.config"}"
 
 DOOM_REPO_URL="https://github.com/doom-neovim/doom-nvim"
-declare -r DOOM_CONFIG_DIR="${DOOM_CONFIG_DIR:-"$XDG_CONFIG_HOME/nvim"}"
+typeset -r DOOM_CONFIG_DIR="${DOOM_CONFIG_DIR:-"$XDG_CONFIG_HOME/nvim"}"
 
-declare BASEDIR
+typeset BASEDIR
 BASEDIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 BASEDIR="$(dirname -- "$(dirname -- "$BASEDIR")")"
 readonly BASEDIR
@@ -26,8 +26,8 @@ function help() {
   echo "    -y, --yes                                Skip all prompts"
 }
 
-declare -a system_dependencies=("nvim" "git" "node" "npm" "fd;optional" "rg;optional" "wget;optional" "unzip;optional")
-declare -a npm_dependencies=("tree-sitter")
+typeset -a system_dependencies=("nvim" "git" "node" "npm" "fd;optional" "rg;optional" "wget;optional" "unzip;optional")
+typeset -a npm_dependencies=("tree-sitter")
 
 function banner() {
     echo "                                                                              "


### PR DESCRIPTION
I had an issue running the script as per instructions in README, but changing it to executable made the shebang actually evaluated. I'm using Alpine with login shell set to fish and apparently ash/fish is not recognizing `#/usr/bin/env bash` unless you run the scripts as executables instead of using a pipe.